### PR TITLE
Fixes export to include named exports (including test)

### DIFF
--- a/lib/process.js
+++ b/lib/process.js
@@ -79,10 +79,10 @@ module.exports = function (src, filePath) {
 
   const map = generateSourceMap(script, '', filePath, scriptSrc, inputMap)
   let output = ';(function(){\n' + script + '\n})()\n' +
-    'if (module.exports.__esModule) module.exports = module.exports.default\n' +
-    'var __vue__options__ = (typeof module.exports === "function"' +
-    '? module.exports.options' +
-    ': module.exports)\n'
+    'var defaultExport = (module.exports.__esModule) ? module.exports.default : module.exports;' +
+    'var __vue__options__ = (typeof defaultExport === "function"' +
+    '? defaultExport.options' +
+    ': defaultExport)\n'
 
   if (parts.template) {
     if (parts.template.src) {

--- a/test/NamedExport.spec.js
+++ b/test/NamedExport.spec.js
@@ -1,0 +1,7 @@
+import { randomExport } from './resources/NamedExport.vue'
+
+describe('NamedExport', () => {
+  it('exports named export "randomExport"', () => {
+    expect(randomExport).toEqual(42)
+  })
+})

--- a/test/resources/NamedExport.vue
+++ b/test/resources/NamedExport.vue
@@ -1,0 +1,7 @@
+<script>
+  export const randomExport = 42;
+
+  export default {
+    name: 'NamedExport'
+  }
+</script>


### PR DESCRIPTION
We encountered some problems while using named exports in Vue components.
While it seems to work well in the vue-loader context, vue-jest seems to just discard named exports.

This pull request fixes this behavior.