### PR TITLE
Avoid parsing LESS, PostCSS too

### DIFF
--- a/lib/process.js
+++ b/lib/process.js
@@ -103,8 +103,8 @@ module.exports = function (src, filePath) {
   if (Array.isArray(parts.styles) && parts.styles.length > 0) {
     const styleStr = parts.styles.map(ast => {
       if (!module) return
-      if (/^scss|sass/.test(ast.lang)) {
-        logger.warn('scss and sass are not currently compiled by vue-jest')
+      if (/^scss|sass|less|pcss|postcss/.test(ast.lang)) {
+        logger.warn('Sass/SCSS, Less and PostCSS are not currently compiled by vue-jest')
         return false
       }
 

--- a/test/less.spec.js
+++ b/test/less.spec.js
@@ -1,0 +1,9 @@
+import { shallow } from 'vue-test-utils'
+import Less from './resources/Less.vue'
+
+describe('processes .vue file with Less style', () => {
+  it('does not error on less', () => {
+    const wrapper = shallow(Less)
+    expect(wrapper.classes()).toContain('testLess')
+  })
+})

--- a/test/postcss.spec.js
+++ b/test/postcss.spec.js
@@ -1,0 +1,9 @@
+import { shallow } from 'vue-test-utils'
+import PostCss from './resources/PostCss.vue'
+
+describe('processes .vue file with PostCSS style', () => {
+  it('does not error on pcss/postcss', () => {
+    const wrapper = shallow(PostCss)
+    expect(wrapper.classes()).toContain('testPcss')
+  })
+})

--- a/test/resources/Less.vue
+++ b/test/resources/Less.vue
@@ -1,0 +1,15 @@
+<template>
+  <div class="testLess"></div>
+</template>
+
+<style lang="less">
+  @import "./styles/transitions";
+
+  .testLess {
+    background-color: red;
+  }
+</style>
+
+<style lang="less">
+  @primary-color: #333;
+</style>

--- a/test/resources/PostCss.vue
+++ b/test/resources/PostCss.vue
@@ -1,0 +1,23 @@
+<template>
+  <div class="testPcss"></div>
+</template>
+
+<style lang="postcss">
+  @import "./styles/transitions";
+
+  .testPcss {
+    background-color: purple;
+  }
+</style>
+
+<style lang="pcss">
+  /* This syntax is for postcss-custom-properties */
+  --primary-color: green;
+
+  /* This syntax is for postcss-nesting, but invalid as Pure CSS */
+  body {
+    @media screen {
+      background-color: grey;
+    }
+  }
+</style>


### PR DESCRIPTION
Other than Sass/SCSS, we may face parsing errors with `cssExtract.extractClasses(cssCode);` in `processStyle (stylePart, filePath)` if you give code which is invalid as pure CSS. `css` module can't parse.

like 

```css
.testPostcCSS {
  body {
    @media screen {
      background-color: red;
    }
  }
}
```

This syntax is allowed for almost CSS preprocessors. Anyway, some other syntaxes may make an exception with `css` module. So, I just added exts to ignore compilation.