### PR TITLE
use empty string when sourceMapText is undefined

### DIFF
--- a/lib/compilers/typescript-compiler.js
+++ b/lib/compilers/typescript-compiler.js
@@ -52,6 +52,9 @@ module.exports = function compileTypescript (scriptContent) {
   const tsConfig = getTypescriptConfig()
 
   const res = typescript.transpileModule(scriptContent, tsConfig)
+  const inputSourceMap = (res.sourceMapText !== undefined)
+    ? JSON.parse(res.sourceMapText)
+    : ''
 
   // handle ES modules in TS source code in case user uses non commonjs module
   // output and there is no .babelrc.
@@ -64,5 +67,5 @@ module.exports = function compileTypescript (scriptContent) {
     }
   }
 
-  return compileBabel(res.outputText, JSON.parse(res.sourceMapText), inlineBabelConfig)
+  return compileBabel(res.outputText, inputSourceMap, inlineBabelConfig)
 }

--- a/test/TypeScript.spec.js
+++ b/test/TypeScript.spec.js
@@ -2,7 +2,7 @@ import { shallow } from 'vue-test-utils'
 import { resolve } from 'path'
 import TypeScript from './resources/TypeScript.vue'
 import jestVue from '../vue-jest'
-import { readFileSync, renameSync } from 'fs'
+import { readFileSync, renameSync, writeFileSync } from 'fs'
 import cache from '../lib/cache'
 
 beforeEach(() => {
@@ -27,4 +27,18 @@ test.skip('generates inline sourcemap', () => {
   const fileString = readFileSync(filePath, { encoding: 'utf8' })
   const output = jestVue.process(fileString, filePath)
   expect(output).toContain(expectedMap)
+})
+
+test('processes without sourcemap', () => {
+  const configPath = resolve(__dirname, '../tsconfig.json')
+  const tsconfigString = readFileSync(configPath, { encoding: 'utf8' })
+  const tsconfig = JSON.parse(tsconfigString)
+  tsconfig.compilerOptions.sourceMap = false
+  writeFileSync(configPath, JSON.stringify(tsconfig))
+  const filePath = resolve(__dirname, './resources/TypeScript.vue')
+  const fileString = readFileSync(filePath, { encoding: 'utf8' })
+
+  expect(() => jestVue.process(fileString, filePath)).not.toThrow()
+
+  writeFileSync(configPath, tsconfigString)
 })

--- a/test/TypeScript.spec.js
+++ b/test/TypeScript.spec.js
@@ -38,7 +38,12 @@ test('processes without sourcemap', () => {
   const filePath = resolve(__dirname, './resources/TypeScript.vue')
   const fileString = readFileSync(filePath, { encoding: 'utf8' })
 
-  expect(() => jestVue.process(fileString, filePath)).not.toThrow()
+  try {
+    expect(() => jestVue.process(fileString, filePath)).not.toThrow()
+  } catch (err) {
+    writeFileSync(configPath, tsconfigString)
+    throw err
+  }
 
   writeFileSync(configPath, tsconfigString)
 })


### PR DESCRIPTION
related: https://github.com/vuejs/vue-jest/issues/60

thank you for creating an awesome repository.
i have same the issue, so i send the this PR to fix it.