### PR TITLE
Add require.context support

### DIFF
--- a/lib/mock_require_context.js
+++ b/lib/mock_require_context.js
@@ -1,0 +1,38 @@
+// src: https://stackoverflow.com/questions/38332094/how-can-i-mock-webpacks-require-context-in-jest
+// This condition actually should detect if it's an Node environment
+module.exports = `if (typeof require.context === 'undefined') {
+  const fs = require('fs');
+  const path = require('path');
+
+  require.context = (base = '.', scanSubDirectories = false, regularExpression = /\.js$/) => {
+    const files = {};
+
+    function readDirectory(directory) {
+      fs.readdirSync(directory).forEach((file) => {
+        const fullPath = path.resolve(directory, file);
+
+        if (fs.statSync(fullPath).isDirectory()) {
+          if (scanSubDirectories) readDirectory(fullPath);
+
+          return;
+        }
+
+        if (!regularExpression.test(fullPath)) return;
+
+        files[fullPath] = true;
+      });
+    }
+
+    readDirectory(path.resolve(__dirname, base));
+
+    function Module(file) {
+      return require(file);
+    }
+
+    Module.keys = () => Object.keys(files);
+
+    return Module;
+  };
+}
+`;
+

--- a/lib/process.js
+++ b/lib/process.js
@@ -7,6 +7,7 @@ const compileTypescript = require('./compilers/typescript-compiler')
 const compileCoffeeScript = require('./compilers/coffee-compiler')
 const extractPropsFromFunctionalTemplate = require('./extract-props')
 const processStyle = require('./process-style')
+const mockRequireContext = require('./mock_require_context')
 const fs = require('fs')
 const path = require('path')
 const join = path.join
@@ -110,6 +111,8 @@ module.exports = function (src, filePath, jestConfig) {
       '\n})()'
     }
   }
+
+  output = mockRequireContext + output;
 
   return { code: output, map }
 }


### PR DESCRIPTION
I know that jest refuses to use require.context, but in many scenarios require.context is very useful, so I hope to mock require.context in vue-jest. I do not know whether this is a correct practice. I hope to thank you for the reply.