### PR TITLE
Global config options for Babel and Typescript

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,18 @@ vue-jest compiles the script and template of SFCs into a JavaScript file that Je
 - **typescript** (`lang="ts"`, `lang="typescript"`)
 - **coffeescript** (`lang="coffee"`, `lang="coffeescript"`)
 
+To define a tsconfig file that vue-jest will use when transpiling typescript, you can specify it in the jest globals
+
+```json
+{
+  "jest": {
+    "vue-jest": {
+      "tsConfigFile": "tsconfig.jest.json"
+    }
+  }
+}
+```
+
 ### Supported template languages
 
 - **pug** (`lang="pug"`)

--- a/README.md
+++ b/README.md
@@ -69,6 +69,18 @@ To define a tsconfig file that vue-jest will use when transpiling typescript, yo
 }
 ```
 
+To define a babelrc file that vue-jest will use when transpiling javascript, you can specify it in the jest globals
+
+```json
+{
+  "jest": {
+    "vue-jest": {
+      "babelRcFile": "jest.babelrc"
+    }
+  }
+}
+```
+
 ### Supported template languages
 
 - **pug** (`lang="pug"`)

--- a/lib/compilers/babel-compiler.js
+++ b/lib/compilers/babel-compiler.js
@@ -1,8 +1,8 @@
 const babel = require('babel-core')
 const loadBabelConfig = require('../load-babel-config.js')
 
-module.exports = function compileBabel (scriptContent, inputSourceMap, inlineConfig) {
-  const babelConfig = inlineConfig || loadBabelConfig()
+module.exports = function compileBabel (scriptContent, inputSourceMap, inlineConfig, vueJestConfig) {
+  const babelConfig = inlineConfig || loadBabelConfig(vueJestConfig)
 
   if (!babelConfig) {
     return {

--- a/lib/compilers/coffee-compiler.js
+++ b/lib/compilers/coffee-compiler.js
@@ -2,7 +2,7 @@ var ensureRequire = require('../ensure-require.js')
 const throwError = require('../throw-error')
 const loadBabelConfig = require('../load-babel-config.js')
 
-module.exports = function (raw) {
+module.exports = function (raw, vueJestConfig) {
   ensureRequire('coffee', ['coffeescript'])
   var coffee = require('coffeescript')
   var compiled
@@ -10,7 +10,7 @@ module.exports = function (raw) {
     compiled = coffee.compile(raw, {
       bare: true,
       sourceMap: true,
-      transpile: loadBabelConfig()
+      transpile: loadBabelConfig(vueJestConfig)
     })
   } catch (err) {
     throwError(err)

--- a/lib/compilers/coffee-compiler.js
+++ b/lib/compilers/coffee-compiler.js
@@ -2,7 +2,7 @@ var ensureRequire = require('../ensure-require.js')
 const throwError = require('../throw-error')
 const loadBabelConfig = require('../load-babel-config.js')
 
-module.exports = function (raw, cb, compiler) {
+module.exports = function (raw) {
   ensureRequire('coffee', ['coffeescript'])
   var coffee = require('coffeescript')
   var compiled

--- a/lib/compilers/typescript-compiler.js
+++ b/lib/compilers/typescript-compiler.js
@@ -3,10 +3,10 @@ const compileBabel = require('./babel-compiler')
 const loadBabelConfig = require('../load-babel-config.js')
 const { loadTypescriptConfig } = require('../load-typescript-config')
 
-module.exports = function compileTypescript (scriptContent) {
+module.exports = function compileTypescript (scriptContent, vueJestConfig) {
   ensureRequire('typescript', ['typescript'])
   const typescript = require('typescript')
-  const tsConfig = loadTypescriptConfig()
+  const tsConfig = loadTypescriptConfig(vueJestConfig)
 
   const res = typescript.transpileModule(scriptContent, tsConfig)
   const inputSourceMap = (res.sourceMapText !== undefined)

--- a/lib/compilers/typescript-compiler.js
+++ b/lib/compilers/typescript-compiler.js
@@ -16,7 +16,7 @@ module.exports = function compileTypescript (scriptContent, vueJestConfig) {
   // handle ES modules in TS source code in case user uses non commonjs module
   // output and there is no .babelrc.
   let inlineBabelConfig
-  if (tsConfig.compilerOptions.module !== 'commonjs' && !loadBabelConfig()) {
+  if (tsConfig.compilerOptions.module !== 'commonjs' && !loadBabelConfig(vueJestConfig)) {
     inlineBabelConfig = {
       plugins: [
         require('babel-plugin-transform-es2015-modules-commonjs')
@@ -24,5 +24,5 @@ module.exports = function compileTypescript (scriptContent, vueJestConfig) {
     }
   }
 
-  return compileBabel(res.outputText, inputSourceMap, inlineBabelConfig)
+  return compileBabel(res.outputText, inputSourceMap, inlineBabelConfig, vueJestConfig)
 }

--- a/lib/load-babel-config.js
+++ b/lib/load-babel-config.js
@@ -1,21 +1,32 @@
 const findBabelConfig = require('find-babel-config')
 const logger = require('./logger')
 const cache = require('./cache')
+const { readFileSync } = require('fs')
 
-module.exports = function getBabelConfig () {
+module.exports = function getBabelConfig (vueJestConfig) {
   const cachedConfig = cache.get('babel-config')
   if (cachedConfig) {
     return cachedConfig
   } else if (cachedConfig === false) {
     return
   } else {
-    const { file, config } = findBabelConfig.sync(process.cwd(), 0)
-    if (!file) {
-      logger.info('no .babelrc found, skipping babel compilation')
-      cache.set('babel-config', false)
-      return
+    let babelConfig
+
+    if (vueJestConfig.babelRcFile) {
+      babelConfig = JSON.parse(readFileSync(vueJestConfig.babelRcFile))
+    } else {
+      const { file, config } = findBabelConfig.sync(process.cwd(), 0)
+
+      if (!file) {
+        logger.info('no .babelrc found, skipping babel compilation')
+        cache.set('babel-config', false)
+        return
+      }
+
+      babelConfig = config
     }
-    cache.set('babel-config', config)
-    return config
+
+    cache.set('babel-config', babelConfig)
+    return babelConfig
   }
 }

--- a/lib/load-typescript-config.js
+++ b/lib/load-typescript-config.js
@@ -26,18 +26,25 @@ const defaultTypescriptConfig = {
   }
 }
 
-module.exports.loadTypescriptConfig = function loadTypescriptConfig () {
+module.exports.loadTypescriptConfig = function loadTypescriptConfig (vueJestConfig) {
   const cachedConfig = cache.get('typescript-config')
   if (cachedConfig) {
     return cachedConfig
   } else {
-    const { path, config } = tsconfig.loadSync(process.cwd())
+    let typescriptConfig
 
-    if (!path) {
-      logger.info('no tsconfig.json found, defaulting to default typescript options')
+    if (vueJestConfig.tsConfigFile) {
+      typescriptConfig = tsconfig.readFileSync(vueJestConfig.tsConfigFile)
+    } else {
+      const { path, config } = tsconfig.loadSync(process.cwd())
+
+      if (!path) {
+        logger.info('no tsconfig.json found, defaulting to default typescript options')
+      }
+
+      typescriptConfig = path ? config : defaultTypescriptConfig
     }
 
-    const typescriptConfig = path ? config : defaultTypescriptConfig
     cache.set('typescript-config', typescriptConfig)
     return typescriptConfig
   }

--- a/lib/process.js
+++ b/lib/process.js
@@ -14,13 +14,13 @@ const join = path.join
 const logger = require('./logger')
 const splitRE = /\r?\n/g
 
-function processScript (scriptPart) {
+function processScript (scriptPart, vueJestConfig) {
   if (!scriptPart) {
     return { code: '' }
   }
 
   if (/^typescript|tsx?$/.test(scriptPart.lang)) {
-    return compileTypescript(scriptPart.content)
+    return compileTypescript(scriptPart.content, vueJestConfig)
   }
 
   if (scriptPart.lang === 'coffee' || scriptPart.lang === 'coffeescript') {
@@ -51,7 +51,7 @@ module.exports = function (src, filePath, jestConfig) {
     parts.script.content = fs.readFileSync(join(filePath, '..', parts.script.src), 'utf8')
   }
 
-  const result = processScript(parts.script)
+  const result = processScript(parts.script, vueJestConfig)
   const script = result.code
   const inputMap = result.sourceMap
 

--- a/lib/process.js
+++ b/lib/process.js
@@ -24,10 +24,10 @@ function processScript (scriptPart, vueJestConfig) {
   }
 
   if (scriptPart.lang === 'coffee' || scriptPart.lang === 'coffeescript') {
-    return compileCoffeeScript(scriptPart.content)
+    return compileCoffeeScript(scriptPart.content, vueJestConfig)
   }
 
-  return compileBabel(scriptPart.content)
+  return compileBabel(scriptPart.content, undefined, undefined, vueJestConfig)
 }
 
 function changePartsIfFunctional (parts) {

--- a/test/load-typescript-config.spec.js
+++ b/test/load-typescript-config.spec.js
@@ -4,7 +4,9 @@ import {
   createReadStream,
   createWriteStream,
   readFileSync,
-  renameSync
+  writeFileSync,
+  renameSync,
+  unlinkSync
 } from 'fs'
 import clearModule from 'clear-module'
 import cache from '../lib/cache'
@@ -20,7 +22,7 @@ describe('load-typescript-config.js', () => {
     const tempPath = resolve(__dirname, '../.renamed')
     renameSync(tsconfigPath, tempPath)
 
-    const tsConfig = loadTypescriptConfig()
+    const tsConfig = loadTypescriptConfig({})
 
     try {
       expect(tsConfig).toEqual(defaultConfig)
@@ -34,16 +36,34 @@ describe('load-typescript-config.js', () => {
     expect(tsconfigCachedConfig).toEqual(defaultConfig)
   })
 
+  it('returns the tsconfig specified in jest globals', () => {
+    const jestGlobalTsConfigPath = resolve(__dirname, '../tsconfig.jest.json')
+
+    writeFileSync(jestGlobalTsConfigPath, JSON.stringify({
+      allowJs: false
+    }))
+
+    const jestGlobalTsConfig = JSON.parse(readFileSync(jestGlobalTsConfigPath, { encoding: 'utf8' }))
+
+    const tsconfig = loadTypescriptConfig({
+      tsConfigFile: jestGlobalTsConfigPath
+    })
+
+    expect(tsconfig).toEqual(jestGlobalTsConfig)
+
+    unlinkSync(jestGlobalTsConfigPath)
+  })
+
   it('reads default tsconfig if there is tsconfig.json', () => {
     const tsconfigPath = resolve(__dirname, '../tsconfig.json')
     const tsconfigCopiedPath = resolve(__dirname, '../.tsconfig.json_cp')
     createReadStream(tsconfigPath).pipe(createWriteStream(tsconfigCopiedPath))
     const tsconfigOriginal = JSON.parse(readFileSync(tsconfigPath, { encoding: 'utf8' }))
-    const tsconfig = loadTypescriptConfig()
+    const tsconfig = loadTypescriptConfig({})
     expect(tsconfig).toEqual(tsconfigOriginal)
     const tempPath = resolve(__dirname, '../.renamed')
     renameSync(tsconfigCopiedPath, tempPath)
-    const tsconfigCached = loadTypescriptConfig()
+    const tsconfigCached = loadTypescriptConfig({})
     try {
       expect(tsconfig).not.toBe(tsconfigCached)
       expect(tsconfig).toEqual(tsconfigCached)


### PR DESCRIPTION
This adds the capability to specify configurations for both babel and typescript in the Jest globals config.

Supercedes #53