### PR TITLE
Improve .babelrc lookup

### DIFF
--- a/lib/compilers/babel-compiler.js
+++ b/lib/compilers/babel-compiler.js
@@ -1,8 +1,8 @@
 const babel = require('babel-core')
 const loadBabelConfig = require('../load-babel-config.js')
 
-module.exports = function compileBabel (scriptContent, inputSourceMap, inlineConfig, vueJestConfig) {
-  const babelConfig = inlineConfig || loadBabelConfig(vueJestConfig)
+module.exports = function compileBabel (scriptContent, inputSourceMap, inlineConfig, vueJestConfig, filePath) {
+  const babelConfig = inlineConfig || loadBabelConfig(vueJestConfig, filePath)
 
   if (!babelConfig) {
     return {

--- a/lib/compilers/coffee-compiler.js
+++ b/lib/compilers/coffee-compiler.js
@@ -2,7 +2,7 @@ var ensureRequire = require('../ensure-require.js')
 const throwError = require('../throw-error')
 const loadBabelConfig = require('../load-babel-config.js')
 
-module.exports = function (raw, vueJestConfig) {
+module.exports = function (raw, vueJestConfig, filePath) {
   ensureRequire('coffee', ['coffeescript'])
   var coffee = require('coffeescript')
   var compiled
@@ -10,7 +10,7 @@ module.exports = function (raw, vueJestConfig) {
     compiled = coffee.compile(raw, {
       bare: true,
       sourceMap: true,
-      transpile: loadBabelConfig(vueJestConfig)
+      transpile: loadBabelConfig(vueJestConfig, filePath)
     })
   } catch (err) {
     throwError(err)

--- a/lib/compilers/typescript-compiler.js
+++ b/lib/compilers/typescript-compiler.js
@@ -3,7 +3,7 @@ const compileBabel = require('./babel-compiler')
 const loadBabelConfig = require('../load-babel-config.js')
 const { loadTypescriptConfig } = require('../load-typescript-config')
 
-module.exports = function compileTypescript (scriptContent, vueJestConfig) {
+module.exports = function compileTypescript (scriptContent, vueJestConfig, filePath) {
   ensureRequire('typescript', ['typescript'])
   const typescript = require('typescript')
   const tsConfig = loadTypescriptConfig(vueJestConfig)
@@ -16,7 +16,7 @@ module.exports = function compileTypescript (scriptContent, vueJestConfig) {
   // handle ES modules in TS source code in case user uses non commonjs module
   // output and there is no .babelrc.
   let inlineBabelConfig
-  if (tsConfig.compilerOptions.module !== 'commonjs' && !loadBabelConfig(vueJestConfig)) {
+  if (tsConfig.compilerOptions.module !== 'commonjs' && !loadBabelConfig(vueJestConfig, filePath)) {
     inlineBabelConfig = {
       plugins: [
         require('babel-plugin-transform-es2015-modules-commonjs')

--- a/lib/load-babel-config.js
+++ b/lib/load-babel-config.js
@@ -4,7 +4,7 @@ const cache = require('./cache')
 const path = require('path')
 const { readFileSync, existsSync } = require('fs')
 
-module.exports = function getBabelConfig (vueJestConfig) {
+module.exports = function getBabelConfig (vueJestConfig, filePath) {
   const cachedConfig = cache.get('babel-config')
   if (cachedConfig) {
     return cachedConfig
@@ -18,7 +18,7 @@ module.exports = function getBabelConfig (vueJestConfig) {
     } else if (existsSync('babel.config.js')) {
       babelConfig = require(path.resolve('babel.config.js'))
     } else {
-      const { file, config } = findBabelConfig.sync(process.cwd(), 0)
+      const { file, config } = findBabelConfig.sync(filePath || process.cwd())
 
       if (!file) {
         logger.info('no .babelrc found, skipping babel compilation')

--- a/lib/process.js
+++ b/lib/process.js
@@ -13,20 +13,20 @@ const join = path.join
 const logger = require('./logger')
 const splitRE = /\r?\n/g
 
-function processScript (scriptPart, vueJestConfig) {
+function processScript (scriptPart, vueJestConfig, filePath) {
   if (!scriptPart) {
     return { code: '' }
   }
 
   if (/^typescript|tsx?$/.test(scriptPart.lang)) {
-    return compileTypescript(scriptPart.content, vueJestConfig)
+    return compileTypescript(scriptPart.content, vueJestConfig, filePath)
   }
 
   if (scriptPart.lang === 'coffee' || scriptPart.lang === 'coffeescript') {
-    return compileCoffeeScript(scriptPart.content, vueJestConfig)
+    return compileCoffeeScript(scriptPart.content, vueJestConfig, filePath)
   }
 
-  return compileBabel(scriptPart.content, undefined, undefined, vueJestConfig)
+  return compileBabel(scriptPart.content, undefined, undefined, vueJestConfig, filePath)
 }
 
 module.exports = function (src, filePath, jestConfig) {
@@ -38,7 +38,7 @@ module.exports = function (src, filePath, jestConfig) {
     parts.script.content = fs.readFileSync(join(filePath, '..', parts.script.src), 'utf8')
   }
 
-  const result = processScript(parts.script, vueJestConfig)
+  const result = processScript(parts.script, vueJestConfig, filePath)
   const script = result.code
   const inputMap = result.sourceMap
 

--- a/test/Babel.spec.js
+++ b/test/Babel.spec.js
@@ -29,23 +29,31 @@ test('processes .vue files using src attributes', () => {
 
 test('skip processing if there is no .babelrc', () => {
   const babelRcPath = resolve(__dirname, '../.babelrc')
+  const babelRcPath2 = resolve(__dirname, '../../.babelrc')
   const tempPath = resolve(__dirname, '../.renamed')
+  const tempPath2 = resolve(__dirname, '../../.renamed')
   renameSync(babelRcPath, tempPath)
+  renameSync(babelRcPath2, tempPath2)
   const filePath = resolve(__dirname, './resources/Basic.vue')
   const fileString = readFileSync(filePath, { encoding: 'utf8' })
   try {
     jestVue.process(fileString, filePath)
   } catch (err) {
     renameSync(tempPath, babelRcPath)
+    renameSync(tempPath2, babelRcPath2)
     throw err
   }
   renameSync(tempPath, babelRcPath)
+  renameSync(tempPath2, babelRcPath2)
 })
 
 test('logs info when there is no .babelrc', () => {
   const babelRcPath = resolve(__dirname, '../.babelrc')
+  const babelRcPath2 = resolve(__dirname, '../../.babelrc')
   const tempPath = resolve(__dirname, '../.renamed')
+  const tempPath2 = resolve(__dirname, '../../.renamed')
   renameSync(babelRcPath, tempPath)
+  renameSync(babelRcPath2, tempPath2)
   const info = jest.spyOn(global.console, 'info')
   const filePath = resolve(__dirname, './resources/Basic.vue')
   const fileString = readFileSync(filePath, { encoding: 'utf8' })
@@ -55,9 +63,11 @@ test('logs info when there is no .babelrc', () => {
     expect(info).toHaveBeenCalledWith('\n[vue-jest]: no .babelrc found, skipping babel compilation\n')
   } catch (err) {
     renameSync(tempPath, babelRcPath)
+    renameSync(tempPath2, babelRcPath2)
     throw err
   }
   renameSync(tempPath, babelRcPath)
+  renameSync(tempPath2, babelRcPath2)
   jest.resetModules()
 })
 

--- a/test/load-babel-config.spec.js
+++ b/test/load-babel-config.spec.js
@@ -70,6 +70,15 @@ describe('load-babel-config.js', () => {
     }
   })
 
+  it('reads .babelrc if it is below the current working directory', () => {
+    const babelRcPath = resolve(__dirname, '../.babelrc')
+    const babelRcContent = JSON.parse(readFileSync(babelRcPath, { encoding: 'utf8' }))
+    process.chdir('test')
+    const babelConfig = loadBabelConfig({})
+    expect(babelConfig).toEqual(babelRcContent)
+    process.chdir('..')
+  })
+
   it('supports babel.config.js', () => {
     const babelConfigPath = resolve(__dirname, '../babel.config.js')
     const config = {

--- a/test/load-babel-config.spec.js
+++ b/test/load-babel-config.spec.js
@@ -19,16 +19,21 @@ describe('load-babel-config.js', () => {
 
   it('returns undefined if there is no .babelrc', () => {
     const babelRcPath = resolve(__dirname, '../.babelrc')
+    const babelRcPath2 = resolve(__dirname, '../../.babelrc')
     const tempPath = resolve(__dirname, '../.renamed')
+    const tempPath2 = resolve(__dirname, '../../.renamed')
     renameSync(babelRcPath, tempPath)
+    renameSync(babelRcPath2, tempPath2)
     const babelConfig = loadBabelConfig({})
     try {
       expect(babelConfig).toBe(undefined)
     } catch (err) {
       renameSync(tempPath, babelRcPath)
+      renameSync(tempPath2, babelRcPath2)
       throw err
     }
     renameSync(tempPath, babelRcPath)
+    renameSync(tempPath2, babelRcPath2)
     const babelConfigCached = loadBabelConfig()
     expect(babelConfigCached).toBe(undefined)
   })

--- a/test/load-babel-config.spec.js
+++ b/test/load-babel-config.spec.js
@@ -79,6 +79,20 @@ describe('load-babel-config.js', () => {
     process.chdir('..')
   })
 
+  it('reads .babelrc from the current working directory', () => {
+    const babelRcPath = resolve(__dirname, '../.babelrc')
+    const babelRcContent = JSON.parse(readFileSync(babelRcPath, { encoding: 'utf8' }))
+    const newBabelRcPath = resolve(__dirname, '../test/.babelrc')
+    const newBabelRcContent = '{"env":{}}'
+    process.chdir('test')
+    writeFileSync(newBabelRcPath, newBabelRcContent)
+    const babelConfig = loadBabelConfig({})
+    expect(babelConfig).toEqual(JSON.parse(newBabelRcContent))
+    expect(babelConfig).not.toEqual(babelRcContent)
+    unlinkSync(newBabelRcPath)
+    process.chdir('..')
+  })
+
   it('supports babel.config.js', () => {
     const babelConfigPath = resolve(__dirname, '../babel.config.js')
     const config = {


### PR DESCRIPTION
Now searches with a depth of infinity from the file path, as described
in #66.

For my personal use, just switching the depth from 0 to the default (INFINITY) was enough; but as per the ticket I try to use the filePath now as well.