### PR TITLE
Allow babelInlineConfig to be passed in

### DIFF
--- a/lib/load-babel-config.js
+++ b/lib/load-babel-config.js
@@ -14,7 +14,9 @@ module.exports = function getBabelConfig (vueJestConfig) {
     let babelConfig
 
     if (vueJestConfig.babelRcFile) {
-      babelConfig = require(vueJestConfig.babelRcFile)
+      babelConfig = JSON.parse(readFileSync(vueJestConfig.babelRcFile))
+    } else if (vueJestConfig.babelConfig) {
+      babelConfig = vueJestConfig.babelConfig
     } else if (existsSync('babel.config.js')) {
       babelConfig = require(path.resolve('babel.config.js'))
     } else {

--- a/lib/load-babel-config.js
+++ b/lib/load-babel-config.js
@@ -14,7 +14,7 @@ module.exports = function getBabelConfig (vueJestConfig) {
     let babelConfig
 
     if (vueJestConfig.babelRcFile) {
-      babelConfig = JSON.parse(readFileSync(vueJestConfig.babelRcFile))
+      babelConfig = require(vueJestConfig.babelRcFile)
     } else if (existsSync('babel.config.js')) {
       babelConfig = require(path.resolve('babel.config.js'))
     } else {

--- a/lib/load-babel-config.js
+++ b/lib/load-babel-config.js
@@ -15,8 +15,6 @@ module.exports = function getBabelConfig (vueJestConfig) {
 
     if (vueJestConfig.babelRcFile) {
       babelConfig = JSON.parse(readFileSync(vueJestConfig.babelRcFile))
-    } else if (vueJestConfig.babelConfig) {
-      babelConfig = vueJestConfig.babelConfig
     } else if (existsSync('babel.config.js')) {
       babelConfig = require(path.resolve('babel.config.js'))
     } else {

--- a/lib/process.js
+++ b/lib/process.js
@@ -29,7 +29,7 @@ function processScript (scriptPart, vueJestConfig, babelInlineConfig) {
   return compileBabel(scriptPart.content, undefined, babelInlineConfig, vueJestConfig)
 }
 
-module.exports = function (src, filePath, jestConfig, babelInlineConfig) {
+module.exports = function (src, filePath, jestConfig, _, babelInlineConfig) {
   const vueJestConfig = getVueJestConfig(jestConfig)
 
   var parts = vueCompiler.parseComponent(src, { pad: true })

--- a/lib/process.js
+++ b/lib/process.js
@@ -13,7 +13,7 @@ const join = path.join
 const logger = require('./logger')
 const splitRE = /\r?\n/g
 
-function processScript (scriptPart, vueJestConfig) {
+function processScript (scriptPart, vueJestConfig, babelInlineConfig) {
   if (!scriptPart) {
     return { code: '' }
   }
@@ -26,10 +26,10 @@ function processScript (scriptPart, vueJestConfig) {
     return compileCoffeeScript(scriptPart.content, vueJestConfig)
   }
 
-  return compileBabel(scriptPart.content, undefined, undefined, vueJestConfig)
+  return compileBabel(scriptPart.content, undefined, babelInlineConfig, vueJestConfig)
 }
 
-module.exports = function (src, filePath, jestConfig) {
+module.exports = function (src, filePath, jestConfig, babelInlineConfig) {
   const vueJestConfig = getVueJestConfig(jestConfig)
 
   var parts = vueCompiler.parseComponent(src, { pad: true })
@@ -38,7 +38,7 @@ module.exports = function (src, filePath, jestConfig) {
     parts.script.content = fs.readFileSync(join(filePath, '..', parts.script.src), 'utf8')
   }
 
-  const result = processScript(parts.script, vueJestConfig)
+  const result = processScript(parts.script, vueJestConfig, babelInlineConfig)
   const script = result.code
   const inputMap = result.sourceMap
 


### PR DESCRIPTION
We are creating our babelConfig programatically and with babel-jest it is already possible to pass that in, but not here. With these changes I can now write my custom vue-jest transform in the following way:

```
...
module.exports = {
    process(src, filename, jestConfig) {
        return vueJest.process(src, filename, jestConfig, {}, babelOptions);
    },
};
```