### PR TITLE
chore(config.yml) use node 8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/node:7.10
+      - image: circleci/node:8
 
     working_directory: ~/repo
 


### PR DESCRIPTION
Hello everybody,

PR for using `circleci/node:8` (Node LTS version) instead of `circleci/node:7.10`.

Regards,