### PR TITLE
use tsconfig.readFileSync

### DIFF
--- a/lib/load-typescript-config.js
+++ b/lib/load-typescript-config.js
@@ -50,7 +50,7 @@ module.exports.loadTypescriptConfig = function loadTypescriptConfig (vueJestConf
       switch (typeof vueJestConfig.tsConfig) {
         case 'string':
           // a path to a config file is being passed in; load it
-          typescriptConfig = require(vueJestConfig.tsConfig)
+          typescriptConfig = tsconfig.readFileSync(vueJestConfig.tsConfig)
           break
         case 'boolean':
           // if tsConfig is true, search for it


### PR DESCRIPTION
howdy! 😄

now tsConfigFile option is deprecated, and we should use tsConfig instead of it.
but i got a JSON.parse error when i switched it.

```
  ● Test suite failed to run

    SyntaxError: Unexpected token m in JSON at position 0
        at JSON.parse (<anonymous>)

      at Object.parseSourceMapInput (node_modules/source-map/lib/util.js:433:15)
      at new SourceMapConsumer (node_modules/source-map/lib/source-map-consumer.js:17:22)
          at Array.map (<anonymous>)
          at Generator.throw (<anonymous>)
```

i made tsConfigFile and tsConfig the same behavior when string supplied to tsConfig.