### PR TITLE
Consider the value of the babelConfig config property before checking for the babel.config.js file

### DIFF
--- a/lib/load-babel-config.js
+++ b/lib/load-babel-config.js
@@ -28,8 +28,6 @@ module.exports = function getBabelConfig (vueJestConfig, filePath) {
     if (vueJestConfig.babelRcFile) {
       deprecate.replace('babelRcFile', 'babelConfig')
       babelConfig = JSON.parse(readFileSync(vueJestConfig.babelRcFile))
-    } else if (existsSync('babel.config.js')) {
-      babelConfig = require(path.resolve('babel.config.js'))
     } else if (vueJestConfig.hasOwnProperty('babelConfig')) {
       switch (typeof vueJestConfig.babelConfig) {
         case 'string':
@@ -49,6 +47,8 @@ module.exports = function getBabelConfig (vueJestConfig, filePath) {
           babelConfig = vueJestConfig.babelConfig
           break
       }
+    } else if (existsSync('babel.config.js')) {
+      babelConfig = require(path.resolve('babel.config.js'))
     } else {
       babelConfig = find()
     }

--- a/test/load-babel-config.spec.js
+++ b/test/load-babel-config.spec.js
@@ -143,6 +143,27 @@ describe('load-babel-config.js', () => {
       findBabelConfig.sync.mockRestore()
     })
 
+    it('should skip configuring babel if false is provided', () => {
+      const config = {
+        plugins: ['foo']
+      }
+      findBabelConfig.sync = jest.fn(() => ({ file: true, config }))
+      const noBabelConfig = loadBabelConfig({
+        babelConfig: false
+      })
+      expect(findBabelConfig.sync).not.toHaveBeenCalled()
+      expect(noBabelConfig).toBeUndefined()
+
+      const babelConfigPath = resolve(__dirname, '../babel.config.js')
+      writeFileSync(babelConfigPath, `module.exports = ${JSON.stringify(config)}`)
+      const babelConfig = loadBabelConfig({
+        babelConfig: false
+      })
+      expect(babelConfig).toBeUndefined()
+      unlinkSync(babelConfigPath)
+      findBabelConfig.sync.mockRestore()
+    })
+
     it('supports an inline babel configuration object', () => {
       const config = {
         plugins: ['foo']

--- a/test/load-babel-config.spec.js
+++ b/test/load-babel-config.spec.js
@@ -143,7 +143,7 @@ describe('load-babel-config.js', () => {
       findBabelConfig.sync.mockRestore()
     })
 
-    it('should skip configuring babel if false is provided', () => {
+    it('should skip configuring babel if a falsey config is provided', () => {
       const config = {
         plugins: ['foo']
       }


### PR DESCRIPTION
A fix for #135 .