### PR TITLE
fix: add mssing argument in getCacheKey

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -8,12 +8,13 @@ module.exports = {
     fileData,
     filename,
     configString,
-    { instrument, rootDir }
+    { config, instrument, rootDir }
   ) {
     return crypto
       .createHash('md5')
       .update(
         babelJest.getCacheKey(fileData, filename, configString, {
+          config,
           instrument,
           rootDir
         }),


### PR DESCRIPTION
Upgrade to vue-jest to 4.0.0-beta failed since `babel-jest` introduced `config` in `getCacheKey` https://github.com/facebook/jest/blob/master/packages/babel-jest/src/index.js#L53

@eddyerburgh Could you give me a review and trigger a new release ?