### PR TITLE
let the script processer pick custom transformers when present

### DIFF
--- a/e2e/__projects__/custom-transformers/babel-transformer.js
+++ b/e2e/__projects__/custom-transformers/babel-transformer.js
@@ -1,0 +1,4 @@
+const { createTransformer } = require('babel-jest')
+module.exports = createTransformer({
+  presets: ['@babel/preset-env']
+})

--- a/e2e/__projects__/custom-transformers/babel.config.js
+++ b/e2e/__projects__/custom-transformers/babel.config.js
@@ -1,3 +1,0 @@
-module.exports = {
-  presets: ['@babel/preset-env']
-}

--- a/e2e/__projects__/custom-transformers/package.json
+++ b/e2e/__projects__/custom-transformers/package.json
@@ -28,7 +28,7 @@
       "vue"
     ],
     "transform": {
-      "^.+\\.js$": "babel-jest",
+      "^.+\\.js$": "./babel-transformer.js",
       "^.+\\.vue$": "vue-jest"
     },
     "moduleNameMapper": {

--- a/lib/process-style.js
+++ b/lib/process-style.js
@@ -59,10 +59,8 @@ module.exports = function processStyle(stylePart, filename, config = {}) {
     getGlobalResources(vueJestConfig.resources, stylePart.lang) +
     stylePart.content
 
-  const transformer = getCustomTransformer(
-    vueJestConfig['transform'],
-    stylePart.lang
-  )
+  const transformer =
+    getCustomTransformer(vueJestConfig['transform'], stylePart.lang) || {}
 
   // pre process
   if (transformer.preprocess) {

--- a/lib/process.js
+++ b/lib/process.js
@@ -10,19 +10,21 @@ const path = require('path')
 const getVueJestConfig = require('./utils').getVueJestConfig
 const logResultErrors = require('./utils').logResultErrors
 const stripInlineSourceMap = require('./utils').stripInlineSourceMap
+const getCustomTransformer = require('./utils').getCustomTransformer
 const throwError = require('./utils').throwError
 const babelTransformer = require('babel-jest')
 const compilerUtils = require('@vue/component-compiler-utils')
 const convertSourceMap = require('convert-source-map')
 const generateCode = require('./generate-code')
 
-function resolveTransformer(lang, vueJestConfig) {
+function resolveTransformer(lang = 'js', vueJestConfig) {
+  const transformer = getCustomTransformer(vueJestConfig['transform'], lang)
   if (/^typescript$|tsx?$/.test(lang)) {
-    return typescriptTransformer
+    return transformer || typescriptTransformer
   } else if (/^coffee$|coffeescript$/.test(lang)) {
-    return coffeescriptTransformer
+    return transformer || coffeescriptTransformer
   } else {
-    return babelTransformer
+    return transformer || babelTransformer
   }
 }
 

--- a/lib/typescript-transformer.js
+++ b/lib/typescript-transformer.js
@@ -11,7 +11,7 @@ module.exports = {
     ensureRequire('typescript', ['typescript'])
     const typescript = require('typescript')
     const vueJestConfig = getVueJestConfig(config)
-    const { tsconfig } = getTsJestConfig(config)
+    const tsconfig = getTsJestConfig(config)
     const babelOptions = getBabelOptions(filePath)
 
     const res = typescript.transpileModule(scriptContent, tsconfig)
@@ -24,7 +24,10 @@ module.exports = {
     // handle ES modules in TS source code in case user uses non commonjs module
     // output and there is no .babelrc.
     let inlineBabelOptions = {}
-    if (tsconfig.compilerOptions.module !== 'commonjs' && !babelOptions) {
+    if (
+      tsconfig.compilerOptions.module !== typescript.ModuleKind.CommonJS &&
+      !babelOptions
+    ) {
       inlineBabelOptions = {
         plugins: [require('@babel/plugin-transform-modules-commonjs')]
       }

--- a/lib/typescript-transformer.js
+++ b/lib/typescript-transformer.js
@@ -29,10 +29,8 @@ module.exports = {
         plugins: [require('@babel/plugin-transform-modules-commonjs')]
       }
     }
-    const customTransformer = getCustomTransformer(
-      vueJestConfig['transform'],
-      'js'
-    )
+    const customTransformer =
+      getCustomTransformer(vueJestConfig['transform'], 'js') || {}
     const transformer = customTransformer.process
       ? customTransformer
       : babelJest.createTransformer(

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -64,7 +64,8 @@ const getBabelOptions = function loadBabelOptions(filename, options = {}) {
 
 const getTsJestConfig = function getTsJestConfig(config) {
   const tr = createTransformer()
-  return tr.configsFor(config)
+  const { typescript } = tr.configsFor(config)
+  return { compilerOptions: typescript.options }
 }
 
 function isValidTransformer(transformer) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -93,7 +93,7 @@ const getCustomTransformer = function getCustomTransformer(
     }
     return transformer
   }
-  return {}
+  return null
 }
 
 const throwError = function error(msg) {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "format": "prettier --no-semi --single-quote --write '**/*.{js,json,md}'",
     "format:check": "prettier --no-semi --single-quote --check '**/*.{js,json,md}'",
     "lint": "eslint --ignore-path .gitignore '{,!(node_modules)/**/}*.js'",
-    "lint:fix": "npm run lint -- --fix",
+    "lint:fix": "npm run lint --fix",
     "release": "semantic-release",
     "test": "npm run lint && npm run format:check && npm run test:e2e",
     "test:e2e": "node e2e/test-runner"


### PR DESCRIPTION
This PR enables the use of custom script transformers, resolves extends property from tsconfig.json.

Similar to custom CSS transformers this help when we have any custom processing to the script(ts/js/coffee).

For eg. When users do not have babel.config.js at the root of the application but have it at a specific location, we can create a custom babel-transformer by passing in babel-jest's `createTransformer(babelConfig)`  with the config pointing to the babel configuration.

Fixes, #148, #144 