### PR TITLE
fix: remove typescript dep

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,5 @@
 const crypto = require('crypto')
 const babelJest = require('babel-jest')
-const tsJest = require('ts-jest')
 
 module.exports = {
   process: require('./process'),
@@ -15,13 +14,6 @@ module.exports = {
       .update(
         babelJest.getCacheKey(fileData, filename, configString, {
           config,
-          instrument,
-          rootDir
-        }),
-        'hex'
-      )
-      .update(
-        tsJest.getCacheKey(fileData, filename, configString, {
           instrument,
           rootDir
         }),

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,5 +1,4 @@
 const loadPartialConfig = require('@babel/core').loadPartialConfig
-const createTransformer = require('ts-jest').createTransformer
 const chalk = require('chalk')
 const path = require('path')
 const fs = require('fs')
@@ -64,6 +63,7 @@ const getBabelOptions = function loadBabelOptions(filename, options = {}) {
 }
 
 const getTsJestConfig = function getTsJestConfig(config) {
+  const createTransformer = require('ts-jest').createTransformer
   const tr = createTransformer()
   const { typescript } = tr.configsFor(config)
   return { compilerOptions: typescript.options }


### PR DESCRIPTION
- Remove ts-jest imports from root of files

This is a stop gap PR to remove ts-jest imports, which throws an error if typescript isn't installed.

In the future we will remove ts-jest entirely