### PR TITLE
chore: add convert-source-map

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "@babel/plugin-transform-modules-commonjs": "^7.2.0",
     "@vue/component-compiler-utils": "^2.4.0",
     "chalk": "^2.1.0",
+    "convert-source-map": "^1.6.0",
     "extract-from-css": "^0.4.4",
     "source-map": "^0.5.6",
     "ts-jest": "^24.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2200,7 +2200,7 @@ conventional-commits-parser@^3.0.0:
     through2 "^2.0.0"
     trim-off-newlines "^1.0.0"
 
-convert-source-map@^1.1.0, convert-source-map@^1.4.0:
+convert-source-map@^1.1.0, convert-source-map@^1.4.0, convert-source-map@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.6.0.tgz#51b537a8c43e0f04dec1993bffcdd504e758ac20"
   integrity sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==


### PR DESCRIPTION
Used in lib/process.js but not listed in dependencies or peer dependencies.

https://github.com/vuejs/vue-jest/blob/d6f4b716d77bf8a69c1f75abf52a286d4984d356/lib/process.js#L15

Fixes #172