### PR TITLE
Update incorrect Babel 7 instruction in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ npm install --save-dev vue-jest
 
 ### Usage with Babel 7
 
-If you use [jest](https://github.com/facebook/jest) < 24.0.0 and [babel-jest](https://github.com/facebook/jest/tree/master/packages/babel-jest) make sure to install babel-core@bridge
+If you use [jest](https://github.com/facebook/jest) > 24.0.0 and [babel-jest](https://github.com/facebook/jest/tree/master/packages/babel-jest) make sure to install babel-core@bridge
 
 ```bash
 npm install --save-dev babel-core@bridge


### PR DESCRIPTION
The readme doc incorrectly states that if you are using versions lower than 24.0.0 of Jest you should use the babel-core@bridge package. This should be versions _greater_ than 24.0.0

I spent a long time banging my head against the wall over this.