### PR TITLE
chore: add dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "chalk": "^2.1.0",
     "convert-source-map": "^1.6.0",
     "extract-from-css": "^0.4.4",
+    "source-map": "^0.7.3",
     "ts-jest": "^24.0.0"
   },
   "repository": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7600,6 +7600,7 @@ source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.0, source-map@~0.6.1:
 source-map@^0.7.3:
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
+  integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
 
 source-map@~0.1.7:
   version "0.1.43"


### PR DESCRIPTION
`source-map` was accidentally removed in here https://github.com/vuejs/vue-jest/commit/d6c4e475e5498083b6273d73e641a1e3f086d087#diff-b9cfc7f2cdf78a7f4b91a753d10865a2L75

but we need it https://github.com/vuejs/vue-jest/blob/0b0d5e2dcd28da728bc0928efdfa6817df6113e7/lib/generate-source-map.js#L2