### PR TITLE
Support pure functional components

### DIFF
--- a/e2e/__projects__/basic/components/FunctionalSFCRender.vue
+++ b/e2e/__projects__/basic/components/FunctionalSFCRender.vue
@@ -1,0 +1,17 @@
+<script>
+export default {
+  name: 'FunctionalSFCRender',
+  functional: true,
+  render(createElement, { $style }) {
+    return createElement('div', {
+      class: [$style.ModuleClass]
+    })
+  }
+}
+</script>
+
+<style lang="scss" module>
+.ModuleClass {
+  width: auto;
+}
+</style>

--- a/e2e/__projects__/basic/test.js
+++ b/e2e/__projects__/basic/test.js
@@ -6,6 +6,7 @@ import jestVue from 'vue-jest'
 import RenderFunction from './components/RenderFunction.vue'
 import Jade from './components/Jade.vue'
 import FunctionalSFC from './components/FunctionalSFC.vue'
+import FunctionalSFCRender from './components/FunctionalSFCRender.vue'
 import Basic from './components/Basic.vue'
 import BasicSrc from './components/BasicSrc.vue'
 import { randomExport } from './components/NamedExport.vue'
@@ -90,6 +91,12 @@ test('processes functional components', () => {
   expect(wrapper.text().trim()).toBe('foo')
   wrapper.trigger('click')
   expect(clickSpy).toHaveBeenCalledWith(1)
+})
+
+test('processes functional components using render function', () => {
+  const wrapper = mount(FunctionalSFCRender)
+  const CSS_CLASSES = ['ModuleClass']
+  expect(wrapper.classes().toString()).toBe(CSS_CLASSES.toString())
 })
 
 test('processes SFC with functional template from parent', () => {

--- a/lib/process.js
+++ b/lib/process.js
@@ -108,11 +108,11 @@ module.exports = function(src, filename, config) {
 
   const isFunctional =
     (descriptor.template &&
-    descriptor.template.attrs &&
-    descriptor.template.attrs.functional) ||
+      descriptor.template.attrs &&
+      descriptor.template.attrs.functional) ||
     (descriptor.script &&
-     descriptor.script.content && 
-     /functional:\s*true/.test(descriptor.script.content))
+      descriptor.script.content &&
+      /functional:\s*true/.test(descriptor.script.content))
 
   const templateStart = descriptor.template && descriptor.template.start
   const templateLine = src.slice(0, templateStart).split(splitRE).length

--- a/lib/process.js
+++ b/lib/process.js
@@ -107,9 +107,12 @@ module.exports = function(src, filename, config) {
   )
 
   const isFunctional =
-    descriptor.template &&
+    (descriptor.template &&
     descriptor.template.attrs &&
-    descriptor.template.attrs.functional
+    descriptor.template.attrs.functional) ||
+    (descriptor.script &&
+     descriptor.script.content && 
+     /functional:\s*true/.test(descriptor.script.content))
 
   const templateStart = descriptor.template && descriptor.template.start
   const templateLine = src.slice(0, templateStart).split(splitRE).length


### PR DESCRIPTION
Before this PR, a component like the next one would fail to be tested because `$style` would be `undefined`:

```js
<script>
export default {
  name: 'FunctionalSFCRender',
  functional: true,
  render(createElement, { $style }) {
    return createElement('div', {
      class: [$style.ModuleClass]
    })
  }
}
</script>

<style lang="scss" module>
.ModuleClass {
  width: auto;
}
</style>
```

The reason for being a failure is related to a missing `<template>` block, however, a functional component can work properly using `functional: true` and a `render` function. Now it tries to find `functional: true` using a regex. 

This PR also includes a simple test that uses to fail without these changes.