### PR TITLE
fix: pin source-map version

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "chalk": "^2.1.0",
     "convert-source-map": "^1.6.0",
     "extract-from-css": "^0.4.4",
-    "source-map": "^0.7.3",
+    "source-map": "0.5.6",
     "ts-jest": "^24.0.0"
   },
   "repository": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7589,6 +7589,11 @@ source-map@0.4.x:
   dependencies:
     amdefine ">=0.0.4"
 
+source-map@0.5.6:
+  version "0.5.6"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
+  integrity sha1-dc449SvwczxafwwRjYEzSiu19BI=
+
 source-map@^0.5.0, source-map@^0.5.6, source-map@^0.5.7, source-map@~0.5.1:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"


### PR DESCRIPTION
Fix CI tests. They changed their lib - it's promised based now. For now, using the old versions fixes it. We should upgrade sometime.