### PR TITLE
ts-jestを利用していないプロジェクトでgetTsJestConfigが失敗するので、fallbackとして、jest.root直下にあるtsconfig.jsonを拾いに行くようにする

### DIFF
--- a/lib/transformers/typescript.js
+++ b/lib/transformers/typescript.js
@@ -2,7 +2,7 @@ const ensureRequire = require('../ensure-require')
 const babelJest = require('babel-jest')
 const {
   getBabelOptions,
-  getTsJestConfig,
+  getTsConfig,
   stripInlineSourceMap,
   getCustomTransformer,
   getVueJestConfig
@@ -13,7 +13,7 @@ module.exports = {
     ensureRequire('typescript', ['typescript'])
     const typescript = require('typescript')
     const vueJestConfig = getVueJestConfig(config)
-    const tsconfig = getTsJestConfig(config)
+    const tsconfig = getTsConfig(config)
     const babelOptions = getBabelOptions(filePath)
 
     const res = typescript.transpileModule(scriptContent, tsconfig)

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -3,6 +3,7 @@ const loadPartialConfig = require('@babel/core').loadPartialConfig
 const chalk = require('chalk')
 const path = require('path')
 const fs = require('fs')
+const ts = require('typescript')
 
 const fetchTransformer = function fetchTransformer(key, obj) {
   for (const exp in obj) {
@@ -63,11 +64,38 @@ const getBabelOptions = function loadBabelOptions(filename, options = {}) {
   return loadPartialConfig(opts).options
 }
 
-const getTsJestConfig = function getTsJestConfig(config) {
+const getTsConfigByTs = function getTsConfigByTs(config) {
+  const maybeTsConfigPath = path.join(config.rootDir, 'tsconfig.json')
+
+  const result = ts.readConfigFile(maybeTsConfigPath, ts.sys.readFile)
+
+  if (result.error) {
+    return undefined
+  }
+
+  const typescript = ts.parseJsonConfigFileContent(
+    result.config,
+    ts.sys,
+    path.dirname(maybeTsConfigPath),
+    undefined,
+    maybeTsConfigPath
+  )
+  if ('options' in typescript) {
+    return { compilerOptions: typescript.options }
+  }
+}
+
+const getTsConfigByTsJest = function getTsConfigByTsJest(config) {
   const createTransformer = require('ts-jest').createTransformer
   const tr = createTransformer()
   const { typescript } = tr.configsFor(config)
-  return { compilerOptions: typescript.options }
+  if (typescript && 'options' in typescript) {
+    return { compilerOptions: typescript.options }
+  }
+}
+
+const getTsConfig = function getTsConfig(config) {
+  return getTsConfigByTsJest(config) || getTsConfigByTs(config)
 }
 
 function isValidTransformer(transformer) {
@@ -146,7 +174,7 @@ module.exports = {
   throwError,
   logResultErrors,
   getCustomTransformer,
-  getTsJestConfig,
+  getTsConfig,
   getBabelOptions,
   getVueJestConfig,
   transformContent,


### PR DESCRIPTION
以前はts-jestを利用していました.
現在私はjestのtypescriptのtranspileに`@babel/preset-typescript`を利用しています.
ts-jestを利用しない方々は今後も増えます.
ts-jestを利用していないプロジェクトでgetTsJestConfigが失敗するので、fallbackとして、jest.root直下にあるtsconfig.jsonを拾いに行くようにしました.
これは私のプロジェクトで上手く行っています.