### PR TITLE
Force ES5 for TS compilation

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -67,7 +67,8 @@ const getTsJestConfig = function getTsJestConfig(config) {
   const createTransformer = require('ts-jest').createTransformer
   const tr = createTransformer()
   const { typescript } = tr.configsFor(config)
-  return { compilerOptions: typescript.options }
+  // Force es5 to prevent const vue_1 = require('vue') from conflicting
+  return { compilerOptions: { ...typescript.options, target: 'es5' } }
 }
 
 function isValidTransformer(transformer) {


### PR DESCRIPTION
This prevents `const vue_1 = require('vue')` from conflicting, since it will do `var vue_1` instead.

This feels pretty bad, I don't know the correct solution. 🤔 

