### PR TITLE
fix: Sass partials imports from node_modules

### DIFF
--- a/e2e/__projects__/style/components/Scss.vue
+++ b/e2e/__projects__/style/components/Scss.vue
@@ -4,6 +4,7 @@
 
 <style lang="scss" module>
 @import '~__styles/scss-a';
+@import '~vue-jest-test/partial.scss';
 
 .c {
   background-color: $primary-color;

--- a/e2e/__projects__/style/package.json
+++ b/e2e/__projects__/style/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "private": true,
   "scripts": {
-    "test": "jest --no-cache test.js"
+    "test": "node setup.js && jest --no-cache test.js"
   },
   "dependencies": {
     "vue": "^2.5.21",
@@ -17,8 +17,7 @@
     "@vue/test-utils": "^1.0.0-beta.28",
     "jest": "^24.0.0",
     "postcss": "^7.0.13",
-    "sass": "^1.23.7",
-    "vue-jest": "file:../../../"
+    "sass": "^1.23.7"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/e2e/__projects__/style/setup.js
+++ b/e2e/__projects__/style/setup.js
@@ -1,0 +1,9 @@
+const fs = require('fs')
+
+const testDir = 'node_modules/vue-jest-test'
+
+if (!fs.existsSync(testDir)) {
+  fs.mkdirSync(testDir)
+}
+
+fs.openSync(`${testDir}/_partial.scss`, 'w')

--- a/e2e/test-runner.js
+++ b/e2e/test-runner.js
@@ -4,6 +4,11 @@ const fs = require('fs-extra')
 const chalk = require('chalk')
 
 const IGNORE_FILES = ['.DS_Store']
+const cwd = process.cwd()
+
+// Can be run as `yarn test:e2e --cache` to forego reinstalling node_modules, or
+// `yarn test:e2e <projects dir>`, or `yarn test:e2e --cache <projects dir>`.
+const args = process.argv.slice(2)
 
 function success(msg) {
   console.info(chalk.green('\n[vue-jest]: ' + msg + '\n'))
@@ -31,16 +36,30 @@ function runTest(dir) {
 
   const log = msg => info(`(${dir}) ${msg}`)
 
-  log('Running tests')
+  if (!args.filter(arg => arg === '--cache').length) {
+    log('Removing node_modules')
+    fs.removeSync(`${resolvedPath}/node_modules`)
 
-  log('Removing node_modules')
-  fs.removeSync(`${resolvedPath}/node_modules`)
+    log('Removing package-lock.json')
+    fs.removeSync(`${resolvedPath}/package-lock.json`)
 
-  log('Removing package-lock.json')
-  fs.removeSync(`${resolvedPath}/package-lock.json`)
+    log('Installing node_modules')
+    run('npm install --silent')
+  }
 
-  log('Installing node_modules')
-  run('npm install --silent')
+  // For tests that need vue-jest to successfully `require.resolve()` a file in
+  // the project directory's node_modules, we can't symlink vue-jest from a
+  // parent directory (as node module resolution walks up the file tree,
+  // starting from the realpath of the caller), we must copy it.
+  if (
+    !fs.existsSync(`${resolvedPath}/node_modules/vue-jest`) ||
+    !fs.lstatSync(`${resolvedPath}/node_modules/vue-jest`).isSymbolicLink()
+  ) {
+    log('Copying vue-jest into node_modules')
+    fs.mkdirSync(`${resolvedPath}/node_modules/vue-jest`, { recursive: true })
+    run(`cp ${cwd}/package.json node_modules/vue-jest/`)
+    run(`cp -r ${cwd}/lib node_modules/vue-jest/`)
+  }
 
   log('Running tests')
   run('npm run test')
@@ -48,12 +67,18 @@ function runTest(dir) {
   success(`(${dir}) Complete`)
 }
 
-async function testRunner(dir) {
+async function testRunner() {
   const directories = fs
     .readdirSync(path.resolve(__dirname, '__projects__'))
     .filter(d => !IGNORE_FILES.includes(d))
 
-  directories.forEach(runTest)
+  const matches = args.filter(d => directories.includes(d))
+
+  if (matches.length) {
+    matches.forEach(runTest)
+  } else {
+    directories.forEach(runTest)
+  }
 }
 
 testRunner()

--- a/lib/module-name-mapper-helper.js
+++ b/lib/module-name-mapper-helper.js
@@ -11,10 +11,18 @@ const matchModuleImport = /^[^?]*~/
 function resolve(to, importPath, fileType) {
   importPath =
     path.extname(importPath) === '' ? `${importPath}.${fileType}` : importPath
+
   if (path.isAbsolute(importPath)) {
     return importPath
   } else if (matchModuleImport.test(importPath)) {
-    return require.resolve(importPath.replace(matchModuleImport, ''))
+    const dirname = path.dirname(importPath).replace(matchModuleImport, '')
+    const basename = path.basename(importPath)
+
+    try {
+      return require.resolve(path.join(dirname, basename))
+    } catch (_) {
+      return require.resolve(path.join(dirname, `_${basename}`))
+    }
   }
   return path.join(path.dirname(to), importPath)
 }


### PR DESCRIPTION
Sass supports importing partials with or without the leading underscore:
https://sass-lang.com/documentation/at-rules/import#partials

Because `applyModuleNameMapper()` uses `require.resolve()` to employ node module resolution on a bare import, it would throw an exception if the import elided the leading `_` from the basename. For example:

```html
<style lang="scss">
@import "~foo/bar"; // Actual filepath might be `node_modules/foo/_bar.scss`.
</style>
```

Writing the test for this was a bit tricky, so I had to make some changes to the test runner. Node module resolution only ever uses realpaths, so when `module-name-mapper-helper.js` makes calls to `require.resolve()`, node won't be looking in the test directory's `node_modules`. As an aside, can we rename `module-name-mapper-helper.js` to make it more clear that it is a Sass-specific importer? This changeset especially makes it specific to Sass. If that wasn't the intention with that module, then I suppose I could revert it and simply wrap the entirety of `applyModuleNameMapper()` in a `try ... catch` and call it twice.