### PR TITLE
chore: bump @vue/test-utils to release version in /e2e

### DIFF
--- a/e2e/__projects__/babel-in-package/package.json
+++ b/e2e/__projects__/babel-in-package/package.json
@@ -14,7 +14,7 @@
   "devDependencies": {
     "@babel/core": "^7.2.2",
     "@babel/preset-env": "^7.2.3",
-    "@vue/test-utils": "^1.0.0-beta.28",
+    "@vue/test-utils": "^1.0.3",
     "jest": "^24.0.0",
     "vue-jest": "file:../../../"
   },

--- a/e2e/__projects__/babel-in-package/package.json
+++ b/e2e/__projects__/babel-in-package/package.json
@@ -14,7 +14,7 @@
   "devDependencies": {
     "@babel/core": "^7.2.2",
     "@babel/preset-env": "^7.2.3",
-    "@vue/test-utils": "^1.0.3",
+    "@vue/test-utils": "^1.0.5",
     "jest": "^24.0.0",
     "vue-jest": "file:../../../"
   },

--- a/e2e/__projects__/basic/package.json
+++ b/e2e/__projects__/basic/package.json
@@ -14,7 +14,7 @@
   "devDependencies": {
     "@babel/core": "^7.2.2",
     "@babel/preset-env": "^7.2.3",
-    "@vue/test-utils": "^1.0.0-beta.28",
+    "@vue/test-utils": "^1.0.3",
     "babel-helper-vue-jsx-merge-props": "^2.0.3",
     "babel-plugin-syntax-jsx": "^6.18.0",
     "babel-plugin-transform-vue-jsx": "^3.7.0",

--- a/e2e/__projects__/basic/package.json
+++ b/e2e/__projects__/basic/package.json
@@ -14,7 +14,7 @@
   "devDependencies": {
     "@babel/core": "^7.2.2",
     "@babel/preset-env": "^7.2.3",
-    "@vue/test-utils": "^1.0.3",
+    "@vue/test-utils": "^1.0.5",
     "babel-helper-vue-jsx-merge-props": "^2.0.3",
     "babel-plugin-syntax-jsx": "^6.18.0",
     "babel-plugin-transform-vue-jsx": "^3.7.0",

--- a/e2e/__projects__/basic/test.js
+++ b/e2e/__projects__/basic/test.js
@@ -58,27 +58,27 @@ test('generates source maps using src attributes', () => {
 
 test('processes .vue file using jsx', () => {
   const wrapper = mount(Jsx)
-  expect(wrapper.is('div')).toBeTruthy()
+  expect(wrapper.element.tagName).toBe('DIV')
 })
 
 test('processes extended functions', () => {
   const wrapper = mount(Constructor)
-  expect(wrapper.is('div')).toBeTruthy()
+  expect(wrapper.element.tagName).toBe('DIV')
 })
 
 test('processes .vue file with lang set to coffee', () => {
   const wrapper = mount(Coffee)
-  expect(wrapper.is('div')).toBeTruthy()
+  expect(wrapper.element.tagName).toBe('DIV')
 })
 
 test('processes .vue file with lang set to coffeescript', () => {
   const wrapper = mount(CoffeeScript)
-  expect(wrapper.is('div')).toBeTruthy()
+  expect(wrapper.element.tagName).toBe('DIV')
 })
 
 test('processes .vue files with lang set to typescript', () => {
   const wrapper = mount(TypeScript)
-  expect(wrapper.is('div')).toBeTruthy()
+  expect(wrapper.element.tagName).toBe('DIV')
 })
 
 test('processes functional components', () => {
@@ -106,29 +106,29 @@ test('processes SFC with functional template from parent', () => {
 
 test('handles missing script block', () => {
   const wrapper = mount(NoScript)
-  expect(wrapper.contains('footer'))
+  expect(wrapper.element.tagName).toBe('FOOTER')
 })
 
 test('processes .vue file with jade template', () => {
   const wrapper = mount(Jade)
-  expect(wrapper.is('div')).toBeTruthy()
+  expect(wrapper.element.tagName).toBe('DIV')
   expect(wrapper.classes()).toContain('jade')
 })
 
 test('processes pug templates', () => {
   const wrapper = mount(Pug)
-  expect(wrapper.is('div')).toBeTruthy()
+  expect(wrapper.element.tagName).toBe('DIV')
   expect(wrapper.classes()).toContain('pug-base')
   expect(wrapper.find('.pug-extended').exists()).toBeTruthy()
 })
 
 test('supports relative paths when extending templates from .pug files', () => {
   const wrapper = mount(PugRelative)
-  expect(wrapper.is('div')).toBeTruthy()
+  expect(wrapper.element.tagName).toBe('DIV')
   expect(wrapper.find('.pug-relative-base').exists()).toBeTruthy()
 })
 
 test('processes SFC with no template', () => {
   const wrapper = mount(RenderFunction)
-  expect(wrapper.is('section')).toBe(true)
+  expect(wrapper.element.tagName).toBe('SECTION')
 })

--- a/e2e/__projects__/custom-transformers/package.json
+++ b/e2e/__projects__/custom-transformers/package.json
@@ -14,7 +14,7 @@
   "devDependencies": {
     "@babel/core": "^7.2.2",
     "@babel/preset-env": "^7.2.3",
-    "@vue/test-utils": "^1.0.0-beta.28",
+    "@vue/test-utils": "^1.0.3",
     "jest": "^24.0.0",
     "postcss": "^7.0.13",
     "postcss-color-function": "^4.0.1",

--- a/e2e/__projects__/custom-transformers/package.json
+++ b/e2e/__projects__/custom-transformers/package.json
@@ -14,7 +14,7 @@
   "devDependencies": {
     "@babel/core": "^7.2.2",
     "@babel/preset-env": "^7.2.3",
-    "@vue/test-utils": "^1.0.3",
+    "@vue/test-utils": "^1.0.5",
     "jest": "^24.0.0",
     "postcss": "^7.0.13",
     "postcss-color-function": "^4.0.1",

--- a/e2e/__projects__/style/package.json
+++ b/e2e/__projects__/style/package.json
@@ -14,7 +14,7 @@
   "devDependencies": {
     "@babel/core": "^7.2.2",
     "@babel/preset-env": "^7.2.3",
-    "@vue/test-utils": "^1.0.3",
+    "@vue/test-utils": "^1.0.5",
     "jest": "^24.0.0",
     "postcss": "^7.0.13",
     "sass": "^1.23.7",

--- a/e2e/__projects__/style/package.json
+++ b/e2e/__projects__/style/package.json
@@ -14,7 +14,7 @@
   "devDependencies": {
     "@babel/core": "^7.2.2",
     "@babel/preset-env": "^7.2.3",
-    "@vue/test-utils": "^1.0.0-beta.28",
+    "@vue/test-utils": "^1.0.3",
     "jest": "^24.0.0",
     "postcss": "^7.0.13",
     "sass": "^1.23.7",

--- a/e2e/__projects__/style/test.js
+++ b/e2e/__projects__/style/test.js
@@ -8,13 +8,13 @@ import External from './components/External.vue'
 
 test('processes Less', () => {
   const wrapper = mount(Less)
-  expect(wrapper.is('div')).toBeTruthy()
+  expect(wrapper.element.tagName).toBe('DIV')
   expect(wrapper.vm.$style.a).toEqual('a')
 })
 
 test('processes PostCSS', () => {
   const wrapper = mount(PostCss)
-  expect(wrapper.is('section')).toBeTruthy()
+  expect(wrapper.element.tagName).toBe('SECTION')
   expect(wrapper.vm.$style.a).toEqual('a')
   expect(wrapper.vm.$style.b).toEqual('b')
 })

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "devDependencies": {
     "@babel/core": "^7.2.2",
     "@babel/preset-env": "^7.2.3",
-    "@vue/test-utils": "^1.0.3",
+    "@vue/test-utils": "^1.0.5",
     "babel-core": "^7.0.0-bridge.0",
     "babel-jest": "^23.6.0",
     "coffeescript": "^2.3.2",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "devDependencies": {
     "@babel/core": "^7.2.2",
     "@babel/preset-env": "^7.2.3",
-    "@vue/test-utils": "^1.0.0-beta.25",
+    "@vue/test-utils": "^1.0.3",
     "babel-core": "^7.0.0-bridge.0",
     "babel-jest": "^23.6.0",
     "coffeescript": "^2.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1142,10 +1142,10 @@
     source-map "~0.6.1"
     vue-template-es2015-compiler "^1.9.0"
 
-"@vue/test-utils@^1.0.3":
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@vue/test-utils/-/test-utils-1.0.3.tgz#587c4dd9b424b66022f188c19bc605da2ce91c6f"
-  integrity sha512-mmsKXZSGfvd0bH05l4SNuczZ2MqlJH2DWhiul5wJXFxbf/gRRd2UL4QZgozEMQ30mRi9i4/+p4JJat8S4Js64Q==
+"@vue/test-utils@^1.0.5":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@vue/test-utils/-/test-utils-1.0.5.tgz#676e1f986bb93ddc869d9c6cf1c820183d64d92f"
+  integrity sha512-P2x8kXwqfTXesAdfJQN146V1S3QD3Xv9wYZ1B09Oecmg7I3Fpqqo1CwfIn5ivwuXyBPQWFDH4vyBHynnYjIkRg==
   dependencies:
     dom-event-types "^1.0.0"
     lodash "^4.17.15"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1142,9 +1142,10 @@
     source-map "~0.6.1"
     vue-template-es2015-compiler "^1.9.0"
 
-"@vue/test-utils@^1.0.0-beta.25":
-  version "1.0.0-beta.32"
-  resolved "https://registry.yarnpkg.com/@vue/test-utils/-/test-utils-1.0.0-beta.32.tgz#38c3947886236201a3f24b583c73598eb95ccc69"
+"@vue/test-utils@^1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@vue/test-utils/-/test-utils-1.0.3.tgz#587c4dd9b424b66022f188c19bc605da2ce91c6f"
+  integrity sha512-mmsKXZSGfvd0bH05l4SNuczZ2MqlJH2DWhiul5wJXFxbf/gRRd2UL4QZgozEMQ30mRi9i4/+p4JJat8S4Js64Q==
   dependencies:
     dom-event-types "^1.0.0"
     lodash "^4.17.15"


### PR DESCRIPTION
- bump `@vue/test-utils` from `1.0.0-beta.28` to `1.0.3`
- replace deprecated assert functions
  - [Wrapper.contains()](https://vue-test-utils.vuejs.org/api/wrapper/#contains)
  - [Wrapper.is()](https://vue-test-utils.vuejs.org/api/wrapper/#is)