### PR TITLE
docs: fix custom-block processor sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ module.exports = {
    * @param {Object} config The full Jest config
    * @returns {string} The code to be output after processing all of the blocks matched by this type
    */
-  process({blocks, vueOptionsNamepsace, filename, config}) {}
+  process({ blocks, vueOptionsNamepsace, filename, config }) {}
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ module.exports = {
    * @param {Object} config The full Jest config
    * @returns {string} The code to be output after processing all of the blocks matched by this type
    */
-  process(blocks, vueOptionsNamepsace, filename, config) {}
+  process({blocks, vueOptionsNamepsace, filename, config}) {}
 }
 ```
 


### PR DESCRIPTION
`process()` sample in README is different from the [implementation](https://github.com/vuejs/vue-jest/blob/master/lib/process-custom-blocks.js#L11).
This PR fixes it.
