### PR TITLE
fix: convert SourceMapGenerator to RawSourceMap

### DIFF
--- a/lib/process.js
+++ b/lib/process.js
@@ -131,7 +131,7 @@ module.exports = function(src, filename, config) {
     output.renderFnStartLine,
     output.renderFnEndLine,
     templateLine
-  )
+  ).toJSON()
 
   return {
     code: output.code,


### PR DESCRIPTION
Jest requires a `map` property of type `RawSourceMap`, but this package passes `SourceMapGenerator`.
I forgot to fix this in #255, excuse me. 

fixes #241 and facebook/jest#10089