### PR TITLE
fix: change single-quote to double-quote in npm-scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,9 +21,9 @@
     "format": "prettier --no-semi --single-quote --write \"**/*.{js,json,md}\"",
     "format:check": "prettier --no-semi --single-quote --check \"**/*.{js,json,md}\"",
     "lint": "eslint --ignore-path .gitignore \"{,!(node_modules)/**/}*.js\"",
-    "lint:fix": "npm run lint --fix",
+    "lint:fix": "yarn lint --fix",
     "release": "semantic-release",
-    "test": "npm run lint && npm run format:check && npm run test:e2e",
+    "test": "yarn lint && yarn format:check && yarn test:e2e",
     "test:e2e": "node e2e/test-runner"
   },
   "author": "Edd Yerburgh",
@@ -85,7 +85,7 @@
   },
   "lint-staged": {
     "*.{js,json,css,md,vue}": [
-      "npm run format",
+      "yarn format",
       "git add"
     ]
   }

--- a/package.json
+++ b/package.json
@@ -18,9 +18,9 @@
     "vue jest preprocessor"
   ],
   "scripts": {
-    "format": "prettier --no-semi --single-quote --write '**/*.{js,json,md}'",
-    "format:check": "prettier --no-semi --single-quote --check '**/*.{js,json,md}'",
-    "lint": "eslint --ignore-path .gitignore '{,!(node_modules)/**/}*.js'",
+    "format": "prettier --no-semi --single-quote --write \"**/*.{js,json,md}\"",
+    "format:check": "prettier --no-semi --single-quote --check \"**/*.{js,json,md}\"",
+    "lint": "eslint --ignore-path .gitignore \"{,!(node_modules)/**/}*.js\"",
     "lint:fix": "npm run lint --fix",
     "release": "semantic-release",
     "test": "npm run lint && npm run format:check && npm run test:e2e",


### PR DESCRIPTION
Windows PowerShell does not support single-quoted arguments.
This repo hooks npm script on commit, so we cannot develop in windows environment.

This PR changes args to double-quoted, and changes `npm run` command to `yarn`.