### PR TITLE
fix: external css files src resolution

### DIFF
--- a/e2e/__projects__/style/components/External.vue
+++ b/e2e/__projects__/style/components/External.vue
@@ -6,6 +6,8 @@
 
 <style module src="./styles/external.css" />
 
+<style module="$style2" src="~__styles/external.css" />
+
 <style module="css">
 .a {
   background: color(red a(90%));

--- a/e2e/__projects__/style/test.js
+++ b/e2e/__projects__/style/test.js
@@ -45,5 +45,6 @@ test('process External', () => {
   const wrapper = mount(External)
   expect(wrapper.vm).toBeTruthy()
   expect(wrapper.vm.$style.testClass).toEqual('testClass')
+  expect(wrapper.vm.$style2.testClass).toEqual('testClass')
   expect(wrapper.vm.css.a).toEqual('a')
 })

--- a/lib/process-style.js
+++ b/lib/process-style.js
@@ -53,7 +53,14 @@ module.exports = function processStyle(stylePart, filePath, config = {}) {
   const vueJestConfig = getVueJestConfig(config)
 
   if (stylePart.src && !stylePart.content) {
-    stylePart.content = loadSrc(stylePart.src, filePath)
+    const cssFilePath = applyModuleNameMapper(
+      stylePart.src,
+      filePath,
+      config,
+      stylePart.lang
+    )
+    stylePart.content = loadSrc(cssFilePath, filePath)
+    filePath = cssFilePath
   }
 
   if (vueJestConfig.experimentalCSSCompile === false || !stylePart.content) {


### PR DESCRIPTION
Follow up of #158 PR - external css files might use paths which needs `moduleNameMapper` resolution.

In case of the app I'm working on, we use external SCSS in a following way:
```html
<style lang="scss" src="@/assets/stylesheets/_bootstrap.module.scss" module="$styleBootstrap" />
```

`vue-jest` have failed in this case, because it always tried to load `style.src` as a relative path.
Now, the `moduleNameMapper` is used to resolve correct, absolute path before anything else happens.

Change have been tested - I think this one, simple test is enough to cover it, what do you think?