### PR TITLE
fix: external css properly handle html5-compliant syntax

### DIFF
--- a/e2e/__projects__/style/components/External.vue
+++ b/e2e/__projects__/style/components/External.vue
@@ -8,6 +8,8 @@
 
 <style module="$style2" src="~__styles/external.css" />
 
+<style module="$style3" src="./styles/external.css"></style>
+
 <style module="css">
 .a {
   background: color(red a(90%));

--- a/e2e/__projects__/style/test.js
+++ b/e2e/__projects__/style/test.js
@@ -46,5 +46,6 @@ test('process External', () => {
   expect(wrapper.vm).toBeTruthy()
   expect(wrapper.vm.$style.testClass).toEqual('testClass')
   expect(wrapper.vm.$style2.testClass).toEqual('testClass')
+  expect(wrapper.vm.$style3.testClass).toEqual('testClass')
   expect(wrapper.vm.css.a).toEqual('a')
 })

--- a/lib/process-style.js
+++ b/lib/process-style.js
@@ -52,7 +52,7 @@ function getPreprocessOptions(lang, filePath, jestConfig) {
 module.exports = function processStyle(stylePart, filePath, config = {}) {
   const vueJestConfig = getVueJestConfig(config)
 
-  if (stylePart.src && !stylePart.content) {
+  if (stylePart.src && !stylePart.content.trim()) {
     const cssFilePath = applyModuleNameMapper(
       stylePart.src,
       filePath,


### PR DESCRIPTION
`vue-jest` fails when using proper html5 syntax when including external css files.

When I import external CSS in a following way (that's something recommended by [vue-loader](https://vue-loader.vuejs.org/spec.html#src-imports) and only way handled properly by vetur - [they do not support highlighting of self-closing `style` tags](https://github.com/vuejs/vetur/issues/1792)):
```html
<style src="./_bootstrap.module.scss" module="$styleBootstrap"></style>
```

`vue-jest` fails - it treats this style block as there would be no `src` attribute at all!


Fixed that case (added `content.trim()` - that's because `vue/component-compiler` for `<style></style>` returns bunch of spaces - something like: "          ").