### PR TITLE
feat: add compile template options

### DIFF
--- a/e2e/__projects__/basic/components/TemplateString.vue
+++ b/e2e/__projects__/basic/components/TemplateString.vue
@@ -1,0 +1,21 @@
+<template>
+  <div
+    :data-sth="
+      gql`
+        query {
+          id
+        }
+      `
+    "
+  />
+</template>
+
+<script lang="ts">
+export default {
+  methods: {
+    gql([str]) {
+      return str
+    }
+  }
+}
+</script>

--- a/e2e/__projects__/basic/package.json
+++ b/e2e/__projects__/basic/package.json
@@ -38,6 +38,13 @@
       "vue-jest": {
         "pug": {
           "basedir": "./"
+        },
+        "templateCompiler": {
+          "transpileOptions": {
+            "transforms": {
+              "dangerousTaggedTemplateString": true
+            }
+          }
         }
       }
     }

--- a/e2e/__projects__/basic/test.js
+++ b/e2e/__projects__/basic/test.js
@@ -1,5 +1,6 @@
 import { mount } from '@vue/test-utils'
 import TypeScript from './components/TypeScript.vue'
+import TemplateString from './components/TemplateString.vue'
 import { resolve } from 'path'
 import { readFileSync } from 'fs'
 import jestVue from 'vue-jest'
@@ -79,6 +80,15 @@ test('processes .vue file with lang set to coffeescript', () => {
 test('processes .vue files with lang set to typescript', () => {
   const wrapper = mount(TypeScript)
   expect(wrapper.element.tagName).toBe('DIV')
+})
+
+test('processes .vue files with template strings in the template', () => {
+  const wrapper = mount(TemplateString)
+  expect(wrapper.attributes('data-sth')).toBe(`
+      query {
+        id
+      }
+    `)
 })
 
 test('processes functional components', () => {

--- a/lib/process.js
+++ b/lib/process.js
@@ -57,16 +57,21 @@ function processTemplate(template, filename, config) {
     template.content = loadSrc(template.src, filename)
   }
 
+  const userTemplateCompilerOptions = vueJestConfig.templateCompiler || {}
   const result = compilerUtils.compileTemplate({
     source: template.content,
     compiler: VueTemplateCompiler,
     filename: filename,
-    compilerOptions: {
-      optimize: false
-    },
     isFunctional: template.attrs.functional,
     preprocessLang: template.lang,
-    preprocessOptions: vueJestConfig[template.lang]
+    preprocessOptions: vueJestConfig[template.lang],
+    ...userTemplateCompilerOptions,
+    compilerOptions: {
+      optimize: false,
+      ...userTemplateCompilerOptions.compilerOptions
+    },
+    transformAssetUrls: { ...userTemplateCompilerOptions.transformAssetUrls },
+    transpileOptions: { ...userTemplateCompilerOptions.transpileOptions }
   })
 
   logResultErrors(result)


### PR DESCRIPTION
Fixes #98.

### What?

This PR is adding to the `vue-jest` possibility to configure the template compiler used by [`@vue/component-compiler-utils` package](https://www.npmjs.com/package/@vue/component-compiler-utils).

### Why?

By passing correct configuration to the template compiler we can mitigate issues like the #98 - where the problem is directly connected with the proper tool configuration (in this case - the [`buble` library](https://www.npmjs.com/package/buble)).
BTW. the graphql case was added in this PR as an e2e test.

### Reproduction scenario

The problem can be reproduced by checking out the first commit in this PR and running `yarn test`. Then you'll see this error in the console:
```bash
FAIL ./test.js
  ● Test suite failed to run

    Tagged template strings are not supported. Use `transforms: { templateString: false }` to skip transformation and disable this error, or `transforms: { dangerousTaggedTemplateString: true }` if you know what you're doing (1:86)

      at Node.initialise (../../../node_modules/vue-template-es2015-compiler/buble.js:16016:10)
          at Array.forEach (<anonymous>)
          at Array.forEach (<anonymous>)
          at Array.forEach (<anonymous>)
          at Array.forEach (<anonymous>)
```