### PR TITLE
fix: add fallback to default TemplateCompileOptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,28 @@ If a string is provided, it will be an assumed path to a TypeScript configuratio
 }
 ```
 
+#### templateCompiler
+
+You can provide [TemplateCompileOptions](https://github.com/vuejs/component-compiler-utils#compiletemplatetemplatecompileoptions-templatecompileresults) in `templateCompiler` section like this:
+
+```json
+{
+  "jest": {
+    "globals": {
+      "vue-jest": {
+        "templateCompiler": {
+          "transpileOptions": {
+            "transforms": {
+              "dangerousTaggedTemplateString": true
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
 ### Supported template languages
 
 - **pug** (`lang="pug"`)

--- a/lib/process.js
+++ b/lib/process.js
@@ -69,9 +69,7 @@ function processTemplate(template, filename, config) {
     compilerOptions: {
       optimize: false,
       ...userTemplateCompilerOptions.compilerOptions
-    },
-    transformAssetUrls: { ...userTemplateCompilerOptions.transformAssetUrls },
-    transpileOptions: { ...userTemplateCompilerOptions.transpileOptions }
+    }
   })
 
   logResultErrors(result)


### PR DESCRIPTION
In #288 PR, `transformAssetUrls` and `transpileOptions` are overwrote to `{}` if `vue-jest.templateCompiler` option is not provided. 
It fails test cases that depend on default TemplateCompileOptions.

This PR:
- Fallback default TemplateCompileOptions if user does not set it.
- Add Documentation of `templateCompiler` option