### PR TITLE
add source map dependency (next)

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "chalk": "^2.1.0",
     "convert-source-map": "^1.6.0",
     "extract-from-css": "^0.4.4",
+    "source-map": "0.5.6",
     "tsconfig": "^7.0.0"
   },
   "repository": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7612,6 +7612,11 @@ source-map@0.4.x:
   dependencies:
     amdefine ">=0.0.4"
 
+source-map@0.5.6:
+  version "0.5.6"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
+  integrity sha1-dc449SvwczxafwwRjYEzSiu19BI=
+
 source-map@^0.5.0, source-map@^0.5.6, source-map@~0.5.1:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"


### PR DESCRIPTION
`vue-jest` has a [dependency](https://github.com/vuejs/vue-jest/blob/next/lib/map-lines.js#L1) on `source-map` but it is not listed in the package.json. This can cause a resolution issue inside a repo with another package that uses `vue-jest` > 0.7 since there was a [breaking change](https://github.com/mozilla/source-map/blob/master/CHANGELOG.md#070).