### PR TITLE
Fix coverage reports for typescript for vue3

### DIFF
--- a/e2e/__projects__/basic/components/TsSrc.ts
+++ b/e2e/__projects__/basic/components/TsSrc.ts
@@ -1,0 +1,23 @@
+export default {
+  name: 'basic',
+  computed: {
+    headingClasses: function headingClasses() {
+      return {
+        red: this.isCrazy,
+        blue: !this.isCrazy,
+        shadow: this.isCrazy
+      }
+    }
+  },
+  data: function data() {
+    return {
+      msg: 'Welcome to Your Vue.js App',
+      isCrazy: false
+    }
+  },
+  methods: {
+    toggleClass: function toggleClass() {
+      this.isCrazy = !this.isCrazy
+    }
+  }
+}

--- a/e2e/__projects__/basic/components/TsSrc.vue
+++ b/e2e/__projects__/basic/components/TsSrc.vue
@@ -1,0 +1,3 @@
+<template src="./BasicSrc.html"></template>
+
+<script lang="ts" src="./TsSrc.ts"></script>

--- a/e2e/__projects__/basic/test.js
+++ b/e2e/__projects__/basic/test.js
@@ -3,6 +3,7 @@ import { resolve } from 'path'
 import { readFileSync } from 'fs'
 
 import BasicSrc from './components/BasicSrc.vue'
+import TsSrc from './components/TsSrc.vue'
 import Pug from './components/Pug.vue'
 import Coffee from './components/Coffee.vue'
 import Basic from './components/Basic.vue'
@@ -46,8 +47,15 @@ test('processes .vue files', () => {
   )
 })
 
-test('processes .vue files with src attributes', () => {
+test('processes .vue files with js src attributes', () => {
   mount(BasicSrc)
+  expect(document.querySelector('h1').textContent).toBe(
+    'Welcome to Your Vue.js App'
+  )
+})
+
+test('processes .vue files with ts src attributes', () => {
+  mount(TsSrc)
   expect(document.querySelector('h1').textContent).toBe(
     'Welcome to Your Vue.js App'
   )

--- a/lib/transformers/typescript.js
+++ b/lib/transformers/typescript.js
@@ -16,7 +16,10 @@ module.exports = {
     const tsconfig = getTsJestConfig(config)
     const babelOptions = getBabelOptions(filePath)
 
-    const res = typescript.transpileModule(scriptContent, tsconfig)
+    const res = typescript.transpileModule(scriptContent, {
+      ...tsconfig,
+      fileName: filePath
+    })
 
     res.outputText = stripInlineSourceMap(res.outputText)
 


### PR DESCRIPTION
This was based on #330 but applied to Vue3.

This properly generates the coverage reports with the filename TsSrc.ts instead of module.ts
```
-   module.ts               |       75 |      100 |    66.67 |       75 |                20 |
+   TsSrc.ts                |       75 |      100 |    66.67 |       75 |                20 |
 ```