### PR TITLE
fix: process render function, exported as default #332

### DIFF
--- a/e2e/__projects__/basic/components/FunctionalRenderFn.vue
+++ b/e2e/__projects__/basic/components/FunctionalRenderFn.vue
@@ -1,0 +1,12 @@
+<script>
+import { h } from 'vue'
+
+export default () =>
+  h(
+    'div',
+    {
+      id: 'functional-render-fn'
+    },
+    'Nyan'
+  )
+</script>

--- a/e2e/__projects__/basic/test.js
+++ b/e2e/__projects__/basic/test.js
@@ -18,6 +18,7 @@ import NoScript from './components/NoScript.vue'
 import PugRelative from './components/PugRelativeExtends.vue'
 import { randomExport } from './components/NamedExport.vue'
 import ScriptSetup from './components/ScriptSetup.vue'
+import FunctionalRenderFn from './components/FunctionalRenderFn.vue'
 
 // TODO: JSX for Vue 3? TSX?
 import Jsx from './components/Jsx.vue'
@@ -157,4 +158,12 @@ xtest('processes SFC with functional template from parent', () => {
 xtest('processes .vue file using jsx', () => {
   mount(Jsx)
   expect(document.querySelector('#jsx')).toBeTruthy()
+})
+
+test('processes functional component exported as function', () => {
+  mount(FunctionalRenderFn)
+
+  const elem = document.querySelector('#functional-render-fn')
+  expect(elem).toBeTruthy()
+  expect(elem.innerHTML).toBe('Nyan')
 })

--- a/lib/generate-code.js
+++ b/lib/generate-code.js
@@ -42,7 +42,7 @@ module.exports = function generateCode(
   if (tempOutput.includes('exports.render = render;')) {
     node.add(';exports.default = {...exports.default, render};')
   } else {
-    node.add(';exports.default = {...exports.default};')
+    // node.add(';exports.default = {...exports.default};')
   }
 
   return node.toStringWithSourceMap({ file: filename })


### PR DESCRIPTION
I just commented out line `node.add(';exports.default = {...exports.default};')`, added simple test, and everything just works.
Perhaps, in some edge cases, you will still need to copy `exports.default` into yourself. Then you can try this option:

```js
node.add(`;
  if (typeof exports.default === 'function') {
    const fn = exports.default;
    exports.default = (...args) => fn(...args);
    Object.assign(exports.default, fn)
  } else {
    exports.default = {...exports.default};
  }
`)
```