### PR TITLE
readme chore: Fix css options appearing all on one line

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,9 @@ You can provide [TemplateCompileOptions](https://github.com/vuejs/component-comp
 ## CSS options
 
 `experimentalCSSCompile`: `Boolean` Default true. Turn off CSS compilation
+
 `hideStyleWarn`: `Boolean` Default false. Hide warnings about CSS compilation
+
 `resources`:
 
 ```json


### PR DESCRIPTION
before this commit all css options appeared on one line