### PR TITLE
fix(deps): add missing devDependencies in e2e/ projects (for 4.x)

### DIFF
--- a/e2e/__projects__/babel-in-package/package.json
+++ b/e2e/__projects__/babel-in-package/package.json
@@ -19,8 +19,7 @@
     "coffeescript": "^2.3.2",
     "jest": "26.x",
     "ts-jest": "^26.3.0",
-    "typescript": "^3.2.2",
-    "vue-jest": "file:../../../"
+    "typescript": "^3.2.2"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/e2e/__projects__/babel-in-package/package.json
+++ b/e2e/__projects__/babel-in-package/package.json
@@ -16,8 +16,10 @@
     "@babel/core": "^7.9.0",
     "@babel/preset-env": "^7.9.0",
     "@vue/test-utils": "^1.1.0",
+    "coffeescript": "^2.3.2",
     "jest": "26.x",
     "ts-jest": "^26.3.0",
+    "typescript": "^3.2.2",
     "vue-jest": "file:../../../"
   },
   "jest": {
@@ -28,7 +30,7 @@
     ],
     "transform": {
       "^.+\\.js$": "babel-jest",
-      "^.+\\.vue$": "file:../../../"
+      "^.+\\.vue$": "vue-jest"
     }
   },
   "babel": {

--- a/e2e/__projects__/basic/package.json
+++ b/e2e/__projects__/basic/package.json
@@ -24,8 +24,7 @@
     "pug": "^3.0.1",
     "sass": "^1.23.7",
     "ts-jest": "^26.3.0",
-    "typescript": "^3.2.2",
-    "vue-jest": "file:../../../"
+    "typescript": "^3.2.2"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/e2e/__projects__/basic/package.json
+++ b/e2e/__projects__/basic/package.json
@@ -18,7 +18,13 @@
     "babel-helper-vue-jsx-merge-props": "^2.0.3",
     "babel-plugin-syntax-jsx": "^6.18.0",
     "babel-plugin-transform-vue-jsx": "^3.7.0",
+    "coffeescript": "^2.3.2",
+    "jade": "^1.11.0",
     "jest": "26.x",
+    "pug": "^3.0.1",
+    "sass": "^1.23.7",
+    "ts-jest": "^26.3.0",
+    "typescript": "^3.2.2",
     "vue-jest": "file:../../../"
   },
   "jest": {

--- a/e2e/__projects__/custom-transformers/package.json
+++ b/e2e/__projects__/custom-transformers/package.json
@@ -18,8 +18,7 @@
     "jest": "26.x",
     "postcss": "^7.0.13",
     "postcss-color-function": "^4.0.1",
-    "sass": "^1.23.7",
-    "vue-jest": "file:../../../"
+    "sass": "^1.23.7"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/e2e/__projects__/style/package.json
+++ b/e2e/__projects__/style/package.json
@@ -19,8 +19,7 @@
     "less": "^3.9.0",
     "postcss": "^7.0.13",
     "sass": "^1.23.7",
-    "stylus": "^0.54.5",
-    "vue-jest": "file:../../../"
+    "stylus": "^0.54.5"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/e2e/__projects__/style/package.json
+++ b/e2e/__projects__/style/package.json
@@ -14,10 +14,13 @@
   "devDependencies": {
     "@babel/core": "^7.9.0",
     "@babel/preset-env": "^7.9.0",
-    "jest": "26.x",
     "@vue/test-utils": "^1.1.0",
+    "jest": "26.x",
+    "less": "^3.9.0",
     "postcss": "^7.0.13",
-    "sass": "^1.23.7"
+    "sass": "^1.23.7",
+    "stylus": "^0.54.5",
+    "vue-jest": "file:../../../"
   },
   "jest": {
     "moduleFileExtensions": [


### PR DESCRIPTION
End-to-end test projects should be independent, but it depends on root `devDependencies` now.

This PR fixes there dependencies.