### PR TITLE
fix: allow importing relative paths in global resources

### DIFF
--- a/e2e/2.x/style/colors.less
+++ b/e2e/2.x/style/colors.less
@@ -1,0 +1,1 @@
+@primary-color: "red";

--- a/e2e/2.x/style/colors.scss
+++ b/e2e/2.x/style/colors.scss
@@ -1,0 +1,1 @@
+$primary-color: #333;

--- a/e2e/2.x/style/variables.less
+++ b/e2e/2.x/style/variables.less
@@ -1,1 +1,3 @@
-@primary-color: "red";
+@import "./colors.less";
+
+@font-size: 16px;

--- a/e2e/2.x/style/variables.scss
+++ b/e2e/2.x/style/variables.scss
@@ -1,1 +1,3 @@
-$primary-color: #333;
+@import './colors.scss';
+
+$font-size: 16px;

--- a/packages/vue2-jest/lib/process-style.js
+++ b/packages/vue2-jest/lib/process-style.js
@@ -40,6 +40,7 @@ function extractClassMap(cssCode) {
 function getPreprocessOptions(lang, filePath, jestConfig) {
   if (lang === 'scss' || lang === 'sass') {
     return {
+      filename: filePath,
       importer: (url, prev, done) => ({
         file: applyModuleNameMapper(
           url,

--- a/packages/vue2-jest/lib/process-style.js
+++ b/packages/vue2-jest/lib/process-style.js
@@ -1,5 +1,4 @@
 const path = require('path')
-const fs = require('fs')
 const cssExtract = require('extract-from-css')
 const getVueJestConfig = require('./utils').getVueJestConfig
 const compileStyle = require('@vue/component-compiler-utils').compileStyle
@@ -12,12 +11,21 @@ function getGlobalResources(resources, lang) {
   let globalResources = ''
   if (resources && resources[lang]) {
     globalResources = resources[lang]
-      .map(resource => path.resolve(process.cwd(), resource))
-      .filter(resourcePath => fs.existsSync(resourcePath))
-      .map(resourcePath => fs.readFileSync(resourcePath).toString())
-      .join('\n')
+      .map(resource => {
+        const absolutePath = path.resolve(process.cwd(), resource)
+        return `${getImportLine(lang, absolutePath)}\n`
+      })
+      .join('')
   }
   return globalResources
+}
+
+function getImportLine(lang, filePath) {
+  const importLines = {
+    default: `@import "${filePath}";`,
+    sass: `@import "${filePath}"`
+  }
+  return importLines[lang] || importLines.default
 }
 
 function extractClassMap(cssCode) {


### PR DESCRIPTION
Closes #374

Fix importing relative paths inside a stylesheet being made globally available using the option `jest.globals['vue-jest'].resources`:

```json
{
  "jest": {
    "globals": {
      "vue-jest": {
        "resources": {
          "scss": [
            "./src/styles/settings/global.scss"
          ]
        }
      }
    }
  }
}
```
**src/styles/settings/global.scss**
```scss
@import './unit.scss';

$another-variable: 10px;
```

considering that _src/styles/settings/unit.scss_ exists, it shouldn't throw the following error

<img width="421" alt="image" src="https://user-images.githubusercontent.com/10983258/128763410-df3dc75e-0c7e-43c1-a4b6-20eb7d013e51.png">

### Version

My branch is based on the `v4.0.1` tag which is the version I'm using. It doesn't seem like there is a `v4` branch I could base my PR on.