### PR TITLE
feat: add compilerOptions to vue-jest global options

### DIFF
--- a/packages/vue3-jest/lib/process.js
+++ b/packages/vue3-jest/lib/process.js
@@ -93,7 +93,8 @@ function processTemplate(descriptor, filename, config) {
     preprocessOptions: vueJestConfig[template.lang],
     compilerOptions: {
       bindingMetadata: bindings,
-      mode: 'module'
+      mode: 'module',
+      ...vueJestConfig.compilerOptions
     }
   })
 


### PR DESCRIPTION
This PR allows to pass down compilerOptions to vue-jest transformation.