### PR TITLE
fix(vue2-jest): interop custom transformer require

### DIFF
--- a/packages/vue2-jest/lib/utils.js
+++ b/packages/vue2-jest/lib/utils.js
@@ -104,6 +104,7 @@ const getCustomTransformer = function getCustomTransformer(
     require(resolvePath(transformerPath))
   ) {
     transformer = require(resolvePath(transformerPath))
+    transformer = transformer.default || transformer
   } else if (typeof transformerPath === 'object') {
     transformer = transformerPath
   }


### PR DESCRIPTION
interop custom transformer require. Some transformers may not interop correctly when requiring, return `transformer.default` or `transformer`.

@vue/vue3-jest fix: #391
fixes #383