### PR TITLE
fix(vue3-jest): interop custom transformer require

### DIFF
--- a/packages/vue3-jest/lib/utils.js
+++ b/packages/vue3-jest/lib/utils.js
@@ -115,6 +115,7 @@ const getCustomTransformer = function getCustomTransformer(
     require(resolvePath(transformerPath))
   ) {
     transformer = require(resolvePath(transformerPath))
+    transformer = transformer.default || transformer
   } else if (typeof transformerPath === 'object') {
     transformer = transformerPath
   }


### PR DESCRIPTION
interop custom transformer require. Some transformers may not interop correctly when requiring, return `transformer.default` or `transformer`.

@vue/vue2-jest fix: #390
fixes #383
