### PR TITLE
feat: support TS in templates for @vue/vue3-jest

### DIFF
--- a/e2e/3.x/typescript/src/components/Basic.vue
+++ b/e2e/3.x/typescript/src/components/Basic.vue
@@ -1,6 +1,8 @@
 <template>
   <div class="hello">
-    <h1 :class="headingClasses">{{ msg }}</h1>
+    <!-- Vue 3.2.13 supports TS in templates -->
+    <!-- hence the `!` after `msg` to check if vue-jest supports it as well -->
+    <h1 :class="headingClasses">{{ msg! }}</h1>
   </div>
 </template>
 

--- a/packages/vue3-jest/lib/process.js
+++ b/packages/vue3-jest/lib/process.js
@@ -91,6 +91,13 @@ function processTemplate(descriptor, filename, config) {
     bindings = scriptSetupResult.bindings
   }
 
+  // Since Vue 3.2.13, it's possible to use TypeScript in templates,
+  // but this needs the `isTS` option of the compiler.
+  // We could let users set it themselves, but vue-loader and vite automatically add it
+  // if the script is in TypeScript, so let's do the same for a seamless experience.
+  const isTS =
+    descriptor.script && /^typescript$|tsx?$/.test(descriptor.script.lang)
+
   const result = compileTemplate({
     id: filename,
     source: template.content,
@@ -100,6 +107,7 @@ function processTemplate(descriptor, filename, config) {
     compilerOptions: {
       bindingMetadata: bindings,
       mode: 'module',
+      isTS,
       ...vueJestConfig.compilerOptions
     }
   })


### PR DESCRIPTION
Vue 3.2.13 introduced the support of TS expressions in templates, with a new `isTs` option of the compiler.
(See [the relevant commit](vuejs/vue-next@0dc521b))

vue-loader and vite chose to enable this by default if the script uses TS:
- [vue-loader](vuejs/vue-loader@7613534)
- [vite](vitejs/vite@01fa2ab)

This commit enables the same behavior in vue-jest: if the script is using TS, then the `isTs` option is passed to the compiler.
TS developers won't have to worry about setting the options themselves, making it coherent with what vue-loader and vite do.