### PR TITLE
feat: pass styleOption into compiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,3 +231,24 @@ You can provide [TemplateCompileOptions](https://github.com/vuejs/component-comp
   }
 }
 ```
+
+## Style options
+
+Possbility to change style loader options (sass, scss, less etc).
+
+`styleOptions`: `Object` Default `{}`.
+
+```json
+{
+  "jest": {
+    "globals": {
+      "vue-jest": {
+        "styleOptions": {
+          "quietDeps" // e.q. sass options https://sass-lang.com/documentation/js-api#quietdeps
+          // unfortunately rest options like `data`, `file` doesnt work because @vue/compiler-component-utils internally overwrite options with their values
+        },
+      }
+    }
+  }
+}
+```

--- a/packages/vue2-jest/lib/process-style.js
+++ b/packages/vue2-jest/lib/process-style.js
@@ -92,7 +92,10 @@ module.exports = function processStyle(stylePart, filePath, config = {}) {
       source: content,
       filePath,
       preprocessLang: stylePart.lang,
-      preprocessOptions,
+      preprocessOptions: {
+        ...preprocessOptions,
+        ...vueJestConfig.styleOptions
+      },
       scoped: false
     })
     logResultErrors(result)


### PR DESCRIPTION
From https://github.com/sass/dart-sass/releases/tag/1.34.0 there are new couple breaking changes e.g `10/2` now should be written as `math.div(10/2)`. With that change there `deprecated` message info which pollutes logs. 
Of course for your own code people can adjust scss/sass/less files, however for external libraries like `bootstrap 4` it's not possible, which means there is a lot of info messages that slows build time. For webpack build we can pass options
`Add a --quiet-deps flag which silences compiler warnings from stylesheets loaded through --load-paths.`
like 
```
loaderOptions: {
    sass: {
        sassOptions: {
           quietDeps: true,
       }
    },
},
```

Thats why I did this PR because its no possible for jest tests to pass additional options such as `quietDeps: true`