### PR TITLE
feat: support TS with script setup

### DIFF
--- a/e2e/3.x/typescript/src/components/ScriptSetup.vue
+++ b/e2e/3.x/typescript/src/components/ScriptSetup.vue
@@ -1,0 +1,18 @@
+<template>
+  <button @click="increase">Count: {{ num }}</button>
+  <Basic />
+  <span>{{ msg! }}</span>
+</template>
+
+<script setup lang="ts">
+import Basic from './Basic.vue'
+import { ref } from 'vue'
+
+const num = ref(5)
+const greet = () => console.log('greet')
+const increase = () => {
+  greet()
+  num.value++
+}
+const msg = 'hello world'
+</script>

--- a/e2e/3.x/typescript/src/test.ts
+++ b/e2e/3.x/typescript/src/test.ts
@@ -1,6 +1,7 @@
 import { createApp, h } from 'vue'
 
 import Basic from '@/components/Basic.vue'
+import ScriptSetup from '@/components/ScriptSetup.vue'
 
 function mount(Component: any) {
   document.getElementsByTagName('html')[0].innerHTML = ''
@@ -20,4 +21,10 @@ test('processes .vue files', () => {
   expect(document.querySelector('h1')!.textContent).toBe(
     'Welcome to Your Vue.js App'
   )
+})
+
+test('supports <script setup>', () => {
+  mount(ScriptSetup)
+  expect(document.body.outerHTML).toContain('Count: 5')
+  expect(document.body.outerHTML).toContain('Welcome to Your Vue.js App')
 })

--- a/packages/vue3-jest/lib/process.js
+++ b/packages/vue3-jest/lib/process.js
@@ -95,8 +95,10 @@ function processTemplate(descriptor, filename, config) {
   // but this needs the `isTS` option of the compiler.
   // We could let users set it themselves, but vue-loader and vite automatically add it
   // if the script is in TypeScript, so let's do the same for a seamless experience.
-  const isTS =
-    descriptor.script && /^typescript$|tsx?$/.test(descriptor.script.lang)
+  const lang =
+    (descriptor.scriptSetup && descriptor.scriptSetup.lang) ||
+    (descriptor.script && descriptor.script.lang)
+  const isTS = /^typescript$|tsx?$/.test(lang)
 
   const result = compileTemplate({
     id: filename,


### PR DESCRIPTION
Automatic _TypeScript detection_ and passing of the `isTS` option was introduced with the pull request #394.
Unfortunately that change was not enough to make this also work for components that utilize `<script setup>`.

The Vue plugin for Vite checks both the `descriptor.scriptSetup.lang` and the `descriptor.script.lang` field the check whether the given component is written in TypeScript: https://github.com/vitejs/vite/blob/b17b5ae68de50413a95fb992ceda92ec0fceaa86/packages/plugin-vue/src/template.ts#L164

This commit enables the same behavior for _script setup components_ by additionally checking the `descriptor.scriptSetup.lang` property.


