### PR TITLE
Change: Remove Jest 27 version specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Since we need to support a variety of Vue and Jest versions, vue-jest doesn't fo
 | Vue 3       | Jest 27           | `@vue/vue3-jest`    |
 
 ```bash
-npm install --save-dev @vue/vue2-jest
+npm install --save-dev @vue/vue2-jest # (use the appropriate version)
 yarn add @vue/vue2-jest --dev
 ```
 

--- a/README.md
+++ b/README.md
@@ -10,12 +10,12 @@ Since we need to support a variety of Vue and Jest versions, vue-jest doesn't fo
 | ----------- | ----------------- | ------------------- |
 | Vue 2       | Jest 26 and below | `vue-jest@4`        |
 | Vue 3       | Jest 26 and below | `vue-jest@5`        |
-| Vue 2       | Jest 27           | `@vue/vue2-jest@27` |
-| Vue 3       | Jest 27           | `@vue/vue3-jest@27` |
+| Vue 2       | Jest 27           | `@vue/vue2-jest`    |
+| Vue 3       | Jest 27           | `@vue/vue3-jest`    |
 
 ```bash
-npm install --save-dev @vue/vue2-jest@27 # (use the appropriate version)
-yarn add @vue/vue2-jest@27 --dev
+npm install --save-dev @vue/vue2-jest
+yarn add @vue/vue2-jest --dev
 ```
 
 ## Setup

--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@ Jest transformer for Vue Single File Components.
 
 Since we need to support a variety of Vue and Jest versions, vue-jest doesn't follow semantic versioning.
 
-| Vue version | Jest Version      | Package             |
-| ----------- | ----------------- | ------------------- |
-| Vue 2       | Jest 26 and below | `vue-jest@4`        |
-| Vue 3       | Jest 26 and below | `vue-jest@5`        |
-| Vue 2       | Jest 27           | `@vue/vue2-jest`    |
-| Vue 3       | Jest 27           | `@vue/vue3-jest`    |
+| Vue version | Jest Version      | Package          |
+| ----------- | ----------------- | ---------------- |
+| Vue 2       | Jest 26 and below | `vue-jest@4`     |
+| Vue 3       | Jest 26 and below | `vue-jest@5`     |
+| Vue 2       | Jest 27           | `@vue/vue2-jest` |
+| Vue 3       | Jest 27           | `@vue/vue3-jest` |
 
 ```bash
 npm install --save-dev @vue/vue2-jest # (use the appropriate version)


### PR DESCRIPTION
Closes #406 
Specifying the version number makes the installation fail. 
Omitting the version number results in installing the correct alpha version.