### PR TITLE
Remove explicit vue-sfc dependency

### DIFF
--- a/packages/vue3-jest/package.json
+++ b/packages/vue3-jest/package.json
@@ -25,7 +25,6 @@
   "license": "MIT",
   "devDependencies": {
     "@babel/core": "^7.9.0",
-    "@vue/compiler-sfc": "^3.2.19",
     "babel-core": "^7.0.0-bridge.0",
     "babel-jest": "^27.0.0",
     "conventional-changelog": "^1.1.5",


### PR DESCRIPTION
It is delivered with Vue by default. 

For more information see  [Issue](https://github.com/vuejs/vue-jest/issues/409)