### PR TITLE
feat: allow to pass compilerOptions via the Jest config for Vue 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,34 @@ vue-jest compiles `<script />`, `<template />`, and `<style />` blocks with supp
 
 You can change the behavior of `vue-jest` by using `jest.globals`.
 
+#### Compiler Options in Vue 3
+
+These options can be used to define Vue compiler options in `@vue/vue3-jest`.
+
+For example, to enable `propsDestructureTransform`:
+
+```js
+globals: {
+  'vue-jest': {
+    compilerOptions: {
+      propsDestructureTransform: true
+    }
+  }
+}
+```
+
+or disable `refTransform` (which is enabled by default):
+
+```js
+globals: {
+  'vue-jest': {
+    compilerOptions: {
+      refTransform: false
+    }
+  }
+}
+```
+
 #### Supporting custom blocks
 
 A great feature of the Vue SFC compiler is that it can support custom blocks. You might want to use those blocks in your tests. To render out custom blocks for testing purposes, you'll need to write a transformer. Once you have your transformer, you'll add an entry to vue-jest's transform map. This is how [vue-i18n's](https://github.com/kazupon/vue-i18n) `<i18n>` custom blocks are supported in unit tests.

--- a/e2e/3.x/babel-in-package/package.json
+++ b/e2e/3.x/babel-in-package/package.json
@@ -7,12 +7,11 @@
     "test": "jest --no-cache test.js"
   },
   "dependencies": {
-    "vue": "^3.2.19"
+    "vue": "^3.2.22"
   },
   "devDependencies": {
     "@babel/core": "^7.9.0",
     "@babel/preset-env": "^7.9.0",
-    "@vue/compiler-sfc": "^3.2.19",
     "coffeescript": "^2.3.2",
     "jest": "^27.0.0",
     "ts-jest": "^27.0.1",

--- a/e2e/3.x/basic/package.json
+++ b/e2e/3.x/basic/package.json
@@ -7,12 +7,11 @@
     "test": "jest --no-cache --coverage test.js"
   },
   "dependencies": {
-    "vue": "^3.2.19"
+    "vue": "^3.2.22"
   },
   "devDependencies": {
     "@babel/core": "^7.9.0",
     "@babel/preset-env": "^7.9.0",
-    "@vue/compiler-sfc": "^3.2.19",
     "babel-helper-vue-jsx-merge-props": "^2.0.3",
     "babel-plugin-syntax-jsx": "^6.18.0",
     "babel-plugin-transform-vue-jsx": "^3.7.0",

--- a/e2e/3.x/custom-transformers/package.json
+++ b/e2e/3.x/custom-transformers/package.json
@@ -7,8 +7,7 @@
     "test": "jest --no-cache --coverage test.js"
   },
   "dependencies": {
-    "@vue/compiler-sfc": "^3.2.19",
-    "vue": "^3.2.19"
+    "vue": "^3.2.22"
   },
   "devDependencies": {
     "@babel/core": "^7.9.0",

--- a/e2e/3.x/javascript/package.json
+++ b/e2e/3.x/javascript/package.json
@@ -7,7 +7,7 @@
     "test": "jest --no-cache test.js"
   },
   "dependencies": {
-    "vue": "^3.2.19"
+    "vue": "^3.2.22"
   },
   "devDependencies": {
     "@babel/core": "^7.9.0",

--- a/e2e/3.x/style/package.json
+++ b/e2e/3.x/style/package.json
@@ -7,8 +7,7 @@
     "test": "jest --no-cache test.js"
   },
   "dependencies": {
-    "@vue/compiler-sfc": "^3.2.19",
-    "vue": "^3.2.19"
+    "vue": "^3.2.22"
   },
   "devDependencies": {
     "@babel/core": "^7.9.0",

--- a/e2e/3.x/typescript-with-babel/package.json
+++ b/e2e/3.x/typescript-with-babel/package.json
@@ -7,8 +7,7 @@
     "test": "jest --no-cache ./sub-project/test.js"
   },
   "dependencies": {
-    "@vue/compiler-sfc": "^3.2.19",
-    "vue": "^3.2.19"
+    "vue": "^3.2.22"
   },
   "devDependencies": {
     "@babel/core": "^7.9.0",

--- a/e2e/3.x/typescript-with-compiler-options/package.json
+++ b/e2e/3.x/typescript-with-compiler-options/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "vue3-typescript-with-compiler-options",
+  "version": "1.0.0",
+  "license": "MIT",
+  "private": true,
+  "scripts": {
+    "test": "jest --no-cache ./src/test.ts"
+  },
+  "dependencies": {
+    "vue": "^3.2.22"
+  },
+  "devDependencies": {
+    "@types/jest": "16.0.10",
+    "jest": "^27.0.0",
+    "ts-jest": "^27.0.1",
+    "typescript": "^4.1.2",
+    "@vue/vue3-jest": "^27.0.0-alpha.1"
+  },
+  "jest": {
+    "testEnvironment": "jsdom",
+    "moduleFileExtensions": [
+      "js",
+      "ts",
+      "json",
+      "vue"
+    ],
+    "moduleNameMapper": {
+      "^@/(.*)$": "<rootDir>/src/$1"
+    },
+    "transform": {
+      "^.+\\.ts$": "ts-jest",
+      "^.+\\.vue$": "@vue/vue3-jest"
+    },
+    "globals": {
+      "vue-jest": {
+        "compilerOptions": {
+          "propsDestructureTransform": true
+        }
+      }
+    }
+  }
+}

--- a/e2e/3.x/typescript-with-compiler-options/src/components/PropsDestructureTransform.vue
+++ b/e2e/3.x/typescript-with-compiler-options/src/components/PropsDestructureTransform.vue
@@ -1,0 +1,7 @@
+<template>
+  <h1>{{ name }}</h1>
+</template>
+
+<script setup lang="ts">
+const { name = 'name' } = defineProps<{ name?: string }>()
+</script>

--- a/e2e/3.x/typescript-with-compiler-options/src/shims-vue.d.ts
+++ b/e2e/3.x/typescript-with-compiler-options/src/shims-vue.d.ts
@@ -1,0 +1,5 @@
+declare module '*.vue' {
+  import type { DefineComponent } from 'vue';
+  const component: DefineComponent<{}, {}, any>;
+  export default component;
+}

--- a/e2e/3.x/typescript-with-compiler-options/src/test.ts
+++ b/e2e/3.x/typescript-with-compiler-options/src/test.ts
@@ -1,0 +1,25 @@
+import { createApp, h } from 'vue'
+
+import PropsDestructureTransform from '@/components/PropsDestructureTransform.vue'
+
+function mount(Component: any) {
+  document.getElementsByTagName('html')[0].innerHTML = ''
+  const el = document.createElement('div')
+  el.id = 'app'
+  document.body.appendChild(el)
+  const Parent = {
+    render() {
+      return h(Component)
+    }
+  }
+  createApp(Parent).mount(el)
+}
+
+test('support additional compiler options like `propsDestructureTransform`', () => {
+  // `propsDestructureTransform` is a new compiler option in v3.2.20
+  // that allows to destructure props with default values and retain reactivity
+  // The option is passed to the compiler via `globals.vue-jest.compilerOptions` of the Jest config in the package.json
+  mount(PropsDestructureTransform)
+  // if the option is properly passed, then the default value of the props is used
+  expect(document.querySelector('h1')!.textContent).toBe('name')
+})

--- a/e2e/3.x/typescript-with-compiler-options/tsconfig.json
+++ b/e2e/3.x/typescript-with-compiler-options/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "module": "esnext",
+    "strict": true,
+    "jsx": "preserve",
+    "importHelpers": true,
+    "moduleResolution": "node",
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "forceConsistentCasingInFileNames": true,
+    "useDefineForClassFields": true,
+    "sourceMap": true,
+    "baseUrl": ".",
+    "types": ["webpack-env", "jest"],
+    "paths": {
+      "@/*": ["src/*"]
+    },
+    "lib": ["esnext", "dom", "dom.iterable", "scripthost"]
+  },
+  "include": ["src/**/*.ts", "src/**/*.vue"],
+  "exclude": ["node_modules"]
+}

--- a/e2e/3.x/typescript/package.json
+++ b/e2e/3.x/typescript/package.json
@@ -7,8 +7,7 @@
     "test": "jest --no-cache ./src/test.ts"
   },
   "dependencies": {
-    "@vue/compiler-sfc": "^3.2.19",
-    "vue": "^3.2.19"
+    "vue": "^3.2.22"
   },
   "devDependencies": {
     "@types/jest": "16.0.10",

--- a/packages/vue3-jest/lib/process.js
+++ b/packages/vue3-jest/lib/process.js
@@ -51,13 +51,14 @@ function processScriptSetup(descriptor, filePath, config) {
   if (!descriptor.scriptSetup) {
     return null
   }
+  const vueJestConfig = getVueJestConfig(config)
   const content = compileScript(descriptor, {
     id: filePath,
-    refTransform: true
+    refTransform: true,
+    ...vueJestConfig.compilerOptions
   })
   const contentMap = mapLines(descriptor.scriptSetup.map, content.map)
 
-  const vueJestConfig = getVueJestConfig(config)
   const transformer = resolveTransformer(
     descriptor.scriptSetup.lang,
     vueJestConfig
@@ -77,7 +78,6 @@ function processTemplate(descriptor, filename, config) {
   }
 
   const vueJestConfig = getVueJestConfig(config)
-
   if (template.src) {
     template.content = loadSrc(template.src, filename)
   }
@@ -86,7 +86,8 @@ function processTemplate(descriptor, filename, config) {
   if (scriptSetup) {
     const scriptSetupResult = compileScript(descriptor, {
       id: filename,
-      refTransform: true
+      refTransform: true,
+      ...vueJestConfig.compilerOptions
     })
     bindings = scriptSetupResult.bindings
   }

--- a/packages/vue3-jest/package.json
+++ b/packages/vue3-jest/package.json
@@ -25,7 +25,6 @@
   "license": "MIT",
   "devDependencies": {
     "@babel/core": "^7.9.0",
-    "@vue/compiler-sfc": "^3.2.19",
     "babel-core": "^7.0.0-bridge.0",
     "babel-jest": "^27.0.0",
     "conventional-changelog": "^1.1.5",
@@ -34,7 +33,7 @@
     "semantic-release": "^15.13.2",
     "ts-jest": "^27.0.1",
     "typescript": "^4.1.2",
-    "vue": "^3.2.19"
+    "vue": "^3.2.22"
   },
   "peerDependencies": {
     "@babel/core": "7.x",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1741,47 +1741,47 @@
     "@vue/babel-plugin-transform-vue-jsx" "^1.2.1"
     camelcase "^5.0.0"
 
-"@vue/compiler-core@3.2.19":
-  version "3.2.19"
-  resolved "https://registry.yarnpkg.com/@vue/compiler-core/-/compiler-core-3.2.19.tgz#b537dd377ce51fdb64e9b30ebfbff7cd70a64cb9"
-  integrity sha512-8dOPX0YOtaXol0Zf2cfLQ4NU/yHYl2H7DCKsLEZ7gdvPK6ZSEwGLJ7IdghhY2YEshEpC5RB9QKdC5I07z8Dtjg==
+"@vue/compiler-core@3.2.22":
+  version "3.2.22"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-core/-/compiler-core-3.2.22.tgz#5e3d3b983cc7f430ddbc6a8773c872dcf410dc89"
+  integrity sha512-uAkovrVeTcjzpiM4ECmVaMrv/bjdgAaLzvjcGqQPBEyUrcqsCgccT9fHJ/+hWVGhyMahmBwLqcn4guULNx7sdw==
   dependencies:
     "@babel/parser" "^7.15.0"
-    "@vue/shared" "3.2.19"
+    "@vue/shared" "3.2.22"
     estree-walker "^2.0.2"
     source-map "^0.6.1"
 
-"@vue/compiler-dom@3.2.19":
-  version "3.2.19"
-  resolved "https://registry.yarnpkg.com/@vue/compiler-dom/-/compiler-dom-3.2.19.tgz#0607bc90de6af55fde73b09b3c4d0bf8cb597ed8"
-  integrity sha512-WzQoE8rfkFjPtIioc7SSgTsnz9g2oG61DU8KHnzPrRS7fW/lji6H2uCYJfp4Z6kZE8GjnHc1Ljwl3/gxDes0cw==
+"@vue/compiler-dom@3.2.22":
+  version "3.2.22"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-dom/-/compiler-dom-3.2.22.tgz#221cc358a6c0651c04e1dd22a8470b21e56ee1a5"
+  integrity sha512-VZdsw/VuO1ODs8K7NQwnMQzKITDkIFlYYC03SVnunuf6eNRxBPEonSyqbWNoo6qNaHAEBTG6VVcZC5xC9bAx1g==
   dependencies:
-    "@vue/compiler-core" "3.2.19"
-    "@vue/shared" "3.2.19"
+    "@vue/compiler-core" "3.2.22"
+    "@vue/shared" "3.2.22"
 
-"@vue/compiler-sfc@3.2.19", "@vue/compiler-sfc@^3.2.19":
-  version "3.2.19"
-  resolved "https://registry.yarnpkg.com/@vue/compiler-sfc/-/compiler-sfc-3.2.19.tgz#d412195a98ebd49b84602f171719294a1d9549be"
-  integrity sha512-pLlbgkO1UHTO02MSpa/sFOXUwIDxSMiKZ1ozE5n71CY4DM+YmI+G3gT/ZHZ46WBId7f3VTF/D8pGwMygcQbrQA==
+"@vue/compiler-sfc@3.2.22":
+  version "3.2.22"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-sfc/-/compiler-sfc-3.2.22.tgz#ffd0e5e35479b6ade18d12fefec369cbaf2f7718"
+  integrity sha512-tWRQ5ge1tsTDhUwHgueicKJ8rYm6WUVAPTaIpFW3GSwZKcOEJ2rXdfkHFShNVGupeRALz2ET2H84OL0GeRxY0A==
   dependencies:
     "@babel/parser" "^7.15.0"
-    "@vue/compiler-core" "3.2.19"
-    "@vue/compiler-dom" "3.2.19"
-    "@vue/compiler-ssr" "3.2.19"
-    "@vue/ref-transform" "3.2.19"
-    "@vue/shared" "3.2.19"
+    "@vue/compiler-core" "3.2.22"
+    "@vue/compiler-dom" "3.2.22"
+    "@vue/compiler-ssr" "3.2.22"
+    "@vue/ref-transform" "3.2.22"
+    "@vue/shared" "3.2.22"
     estree-walker "^2.0.2"
     magic-string "^0.25.7"
     postcss "^8.1.10"
     source-map "^0.6.1"
 
-"@vue/compiler-ssr@3.2.19":
-  version "3.2.19"
-  resolved "https://registry.yarnpkg.com/@vue/compiler-ssr/-/compiler-ssr-3.2.19.tgz#3e91ecf70f8f961c5f63eacd2139bcdab9a7a07c"
-  integrity sha512-oLon0Cn3O7WEYzzmzZavGoqXH+199LT+smdjBT3Uf3UX4HwDNuBFCmvL0TsqV9SQnIgKvBRbQ7lhbpnd4lqM3w==
+"@vue/compiler-ssr@3.2.22":
+  version "3.2.22"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-ssr/-/compiler-ssr-3.2.22.tgz#23552c31b76b45baf5f244713c81d77ab59447d2"
+  integrity sha512-Cl6aoLJtXzzBkk1sKod8S0WBJLts3+ugVC91d22gGpbkw/64WnF12tOZi7Rg54PPLi1NovqyNWPsLH/SAFcu+w==
   dependencies:
-    "@vue/compiler-dom" "3.2.19"
-    "@vue/shared" "3.2.19"
+    "@vue/compiler-dom" "3.2.22"
+    "@vue/shared" "3.2.22"
 
 "@vue/component-compiler-utils@^3.1.0":
   version "3.2.2"
@@ -1799,53 +1799,53 @@
   optionalDependencies:
     prettier "^1.18.2"
 
-"@vue/reactivity@3.2.19":
-  version "3.2.19"
-  resolved "https://registry.yarnpkg.com/@vue/reactivity/-/reactivity-3.2.19.tgz#fc6e0f0106f295226835cfed5ff5f84d927bea65"
-  integrity sha512-FtachoYs2SnyrWup5UikP54xDX6ZJ1s5VgHcJp4rkGoutU3Ry61jhs+nCX7J64zjX992Mh9gGUC0LqTs8q9vCA==
+"@vue/reactivity@3.2.22":
+  version "3.2.22"
+  resolved "https://registry.yarnpkg.com/@vue/reactivity/-/reactivity-3.2.22.tgz#88655c0b4febc561136e6550e329039f860caa0a"
+  integrity sha512-xNkLAItjI0xB+lFeDgKCrSItmrHTaAzSnt8LmdSCPQnDyarmzbi/u4ESQnckWvlL7lSRKiEaOvblaNyqAa7OnQ==
   dependencies:
-    "@vue/shared" "3.2.19"
+    "@vue/shared" "3.2.22"
 
-"@vue/ref-transform@3.2.19":
-  version "3.2.19"
-  resolved "https://registry.yarnpkg.com/@vue/ref-transform/-/ref-transform-3.2.19.tgz#cf0f986486bb26838fbd09749e927bab19745600"
-  integrity sha512-03wwUnoIAeKti5IGGx6Vk/HEBJ+zUcm5wrUM3+PQsGf7IYnXTbeIfHHpx4HeSeWhnLAjqZjADQwW8uA4rBmVbg==
+"@vue/ref-transform@3.2.22":
+  version "3.2.22"
+  resolved "https://registry.yarnpkg.com/@vue/ref-transform/-/ref-transform-3.2.22.tgz#16b03994eac71528cceff4cf76178ed9b44ac90a"
+  integrity sha512-qalVWbq5xWWxLZ0L9OroBg/JZhzavQuCcDXblfErxyDEH6Xc5gIJ4feo1SVCICFzhAUgLgQTdSFLpgjBawbFpw==
   dependencies:
     "@babel/parser" "^7.15.0"
-    "@vue/compiler-core" "3.2.19"
-    "@vue/shared" "3.2.19"
+    "@vue/compiler-core" "3.2.22"
+    "@vue/shared" "3.2.22"
     estree-walker "^2.0.2"
     magic-string "^0.25.7"
 
-"@vue/runtime-core@3.2.19":
-  version "3.2.19"
-  resolved "https://registry.yarnpkg.com/@vue/runtime-core/-/runtime-core-3.2.19.tgz#807715b7f4728abb84fa4a8efdbe37d8ddb4c6d3"
-  integrity sha512-qArZSWKxWsgKfxk9BelZ32nY0MZ31CAW2kUUyVJyxh4cTfHaXGbjiQB5JgsvKc49ROMNffv9t3/qjasQqAH+RQ==
+"@vue/runtime-core@3.2.22":
+  version "3.2.22"
+  resolved "https://registry.yarnpkg.com/@vue/runtime-core/-/runtime-core-3.2.22.tgz#111f1bc97f20249e05ca2189856d99c82d72de32"
+  integrity sha512-e7WOC55wmHPvmoVUk9VBe/Z9k5bJfWJfVIlkUkiADJn0bOgQD29oh/GS14Kb3aEJXIHLI17Em6+HxNut1sIh7Q==
   dependencies:
-    "@vue/reactivity" "3.2.19"
-    "@vue/shared" "3.2.19"
+    "@vue/reactivity" "3.2.22"
+    "@vue/shared" "3.2.22"
 
-"@vue/runtime-dom@3.2.19":
-  version "3.2.19"
-  resolved "https://registry.yarnpkg.com/@vue/runtime-dom/-/runtime-dom-3.2.19.tgz#7e8bf645754703e360fa132e4be9113edf2377bb"
-  integrity sha512-hIRboxXwafeHhbZEkZYNV0MiJXPNf4fP0X6hM2TJb0vssz8BKhD9cF92BkRgZztTQevecbhk0gu4uAPJ3dxL9A==
+"@vue/runtime-dom@3.2.22":
+  version "3.2.22"
+  resolved "https://registry.yarnpkg.com/@vue/runtime-dom/-/runtime-dom-3.2.22.tgz#c11d75dd51375ee4c74e339f6523ca05e37faa37"
+  integrity sha512-w7VHYJoliLRTLc5beN77wxuOjla4v9wr2FF22xpZFYBmH4U1V7HkYhoHc1BTuNghI15CXT1tNIMhibI1nrQgdw==
   dependencies:
-    "@vue/runtime-core" "3.2.19"
-    "@vue/shared" "3.2.19"
+    "@vue/runtime-core" "3.2.22"
+    "@vue/shared" "3.2.22"
     csstype "^2.6.8"
 
-"@vue/server-renderer@3.2.19":
-  version "3.2.19"
-  resolved "https://registry.yarnpkg.com/@vue/server-renderer/-/server-renderer-3.2.19.tgz#870bcec9f7cdaee0c2187a169b6e636ab4362fb1"
-  integrity sha512-A9FNT7fgQJXItwdzWREntAgWKVtKYuXHBKGev/H4+ByTu8vB7gQXGcim01QxaJshdNg4dYuH2tEBZXCNCNx+/w==
+"@vue/server-renderer@3.2.22":
+  version "3.2.22"
+  resolved "https://registry.yarnpkg.com/@vue/server-renderer/-/server-renderer-3.2.22.tgz#049c91a495cb0fcdac02dec485c31cb99410885f"
+  integrity sha512-jCwbQgKPXiXoH9VS9F7K+gyEvEMrjutannwEZD1R8fQ9szmOTqC+RRbIY3Uf2ibQjZtZ8DV9a4FjxICvd9zZlQ==
   dependencies:
-    "@vue/compiler-ssr" "3.2.19"
-    "@vue/shared" "3.2.19"
+    "@vue/compiler-ssr" "3.2.22"
+    "@vue/shared" "3.2.22"
 
-"@vue/shared@3.2.19":
-  version "3.2.19"
-  resolved "https://registry.yarnpkg.com/@vue/shared/-/shared-3.2.19.tgz#111ec3da18337d86274446984c49925b1b2b2dd7"
-  integrity sha512-Knqhx7WieLdVgwCAZgTVrDCXZ50uItuecLh9JdLC8O+a5ayaSyIQYveUK3hCRNC7ws5zalHmZwfdLMGaS8r4Ew==
+"@vue/shared@3.2.22":
+  version "3.2.22"
+  resolved "https://registry.yarnpkg.com/@vue/shared/-/shared-3.2.22.tgz#26dcbe5e530f6c1f2de5ca9aeab92ab00f523b41"
+  integrity sha512-qWVav014mpjEtbWbEgl0q9pEyrrIySKum8UVYjwhC6njrKzknLZPvfuYdQyVbApsqr94tf/3dP4pCuZmmjdCWQ==
 
 "@vue/test-utils@^1.1.0":
   version "1.2.2"
@@ -11050,16 +11050,16 @@ vue@^2.4.2, vue@^2.5.21:
   resolved "https://registry.yarnpkg.com/vue/-/vue-2.6.14.tgz#e51aa5250250d569a3fbad3a8a5a687d6036e235"
   integrity sha512-x2284lgYvjOMj3Za7kqzRcUSxBboHqtgRE2zlos1qWaOye5yUmHn42LB1250NJBLRwEcdrB0JRwyPTEPhfQjiQ==
 
-vue@^3.2.19:
-  version "3.2.19"
-  resolved "https://registry.yarnpkg.com/vue/-/vue-3.2.19.tgz#da2c80a6a0271c7097fee9e31692adfd9d569c8f"
-  integrity sha512-6KAMdIfAtlK+qohTIUE4urwAv4A3YRuo8uAbByApUmiB0CziGAAPs6qVugN6oHPia8YIafHB/37K0O6KZ7sGmA==
+vue@^3.2.22:
+  version "3.2.22"
+  resolved "https://registry.yarnpkg.com/vue/-/vue-3.2.22.tgz#46e4dd89e98cc4b851ae1eb35f00ced413a34bb7"
+  integrity sha512-KD5nZpXVZquOC6926Xnp3zOvswrUyO9Rya7ZUoxWFQEjFDW4iACtwzubRB4Um2Om9kj6CaJOqAVRDSFlqLpdgw==
   dependencies:
-    "@vue/compiler-dom" "3.2.19"
-    "@vue/compiler-sfc" "3.2.19"
-    "@vue/runtime-dom" "3.2.19"
-    "@vue/server-renderer" "3.2.19"
-    "@vue/shared" "3.2.19"
+    "@vue/compiler-dom" "3.2.22"
+    "@vue/compiler-sfc" "3.2.22"
+    "@vue/runtime-dom" "3.2.22"
+    "@vue/server-renderer" "3.2.22"
+    "@vue/shared" "3.2.22"
 
 w3c-hr-time@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
These options can be used to define Vue compiler options in `@vue/vue3-jest`.

For example, to enable the newly introduced `propsDestructureTransform` in Vue v3.2.20:

```js
globals: {
  'vue-jest': {
    compilerOptions: {
      propsDestructureTransform: true
    }
  }
}
```

or to disable `refTransform` (which is enabled by default):

```js
globals: {
  'vue-jest': {
    compilerOptions: {
      refTransform: false
    }
  }
}
```