### PR TITLE
fix(vue3-jest): compilation error while passing tsconfig path

### DIFF
--- a/packages/vue3-jest/lib/utils.js
+++ b/packages/vue3-jest/lib/utils.js
@@ -69,11 +69,8 @@ const getBabelOptions = function loadBabelOptions(filename, options = {}) {
 }
 
 const getTsJestConfig = function getTsJestConfig(config) {
-  const tsConfigPath = path.resolve(
-    process.cwd(),
-    getVueJestConfig(config).tsConfig || ''
-  )
-  const isUsingTs = resolveTsConfigSync(tsConfigPath)
+  const tsConfigPath = getVueJestConfig(config).tsConfig || ''
+  const isUsingTs = resolveTsConfigSync(process.cwd(), tsConfigPath)
   if (!isUsingTs) {
     return null
   }


### PR DESCRIPTION
When the tsconfig path is not the default, I need to manually pass in the tsconfig path.Some configurations are shown below：

```ts
export default {
  globals: {
    'ts-jest': {
      tsconfig: require.resolve('./tsconfig.jest.json'),
    },
    'vue-jest': {
      tsConfig: require.resolve('./tsconfig.jest.json'),
    },
  },
}
```

The [tsconfig#resolveSync](https://github.com/TypeStrong/tsconfig/blob/master/src/tsconfig.ts#L49) method is called in the code to get the configuration. However, the configuration can't be obtained due to incorrect parameter passing, so it is compiled as JS code, resulting in compilation errors