### PR TITLE
feat: load TypeScript config from `tsconfig` package instead of `ts-jest`

### DIFF
--- a/e2e/2.x/babel-in-package/package.json
+++ b/e2e/2.x/babel-in-package/package.json
@@ -20,7 +20,6 @@
     "coffeescript": "^2.3.2",
     "jest": "28.x",
     "jest-environment-jsdom": "28.0.2",
-    "ts-jest": "^28.0.1",
     "typescript": "^4.6.4"
   },
   "jest": {

--- a/e2e/2.x/basic/package.json
+++ b/e2e/2.x/basic/package.json
@@ -14,6 +14,7 @@
     "@babel/core": "^7.9.0",
     "@babel/preset-env": "^7.9.0",
     "@vue/test-utils": "^1.1.0",
+    "@vue/vue2-jest": "^28.0.0",
     "babel-helper-vue-jsx-merge-props": "^2.0.3",
     "babel-plugin-syntax-jsx": "^6.18.0",
     "babel-plugin-transform-vue-jsx": "^3.7.0",
@@ -23,9 +24,7 @@
     "jest-environment-jsdom": "28.0.2",
     "pug": "^3.0.1",
     "sass": "^1.23.7",
-    "ts-jest": "^28.0.1",
-    "typescript": "^4.6.4",
-    "@vue/vue2-jest": "^28.0.0"
+    "typescript": "^4.6.4"
   },
   "jest": {
     "testEnvironment": "jsdom",

--- a/e2e/3.x/babel-in-package/package.json
+++ b/e2e/3.x/babel-in-package/package.json
@@ -12,12 +12,12 @@
   "devDependencies": {
     "@babel/core": "^7.9.0",
     "@babel/preset-env": "^7.9.0",
+    "@vue/vue3-jest": "^28.0.0",
     "coffeescript": "^2.3.2",
     "jest": "^28.0.0",
     "jest-environment-jsdom": "28.0.2",
     "ts-jest": "^28.0.1",
-    "typescript": "^4.6.4",
-    "@vue/vue3-jest": "^28.0.0"
+    "typescript": "^4.6.4"
   },
   "jest": {
     "testEnvironment": "jsdom",

--- a/e2e/3.x/basic/package.json
+++ b/e2e/3.x/basic/package.json
@@ -12,6 +12,7 @@
   "devDependencies": {
     "@babel/core": "^7.9.0",
     "@babel/preset-env": "^7.9.0",
+    "@vue/vue3-jest": "^28.0.0",
     "babel-helper-vue-jsx-merge-props": "^2.0.3",
     "babel-plugin-syntax-jsx": "^6.18.0",
     "babel-plugin-transform-vue-jsx": "^3.7.0",
@@ -23,7 +24,6 @@
     "ts-jest": "^28.0.1",
     "typescript": "^4.6.4",
     "vue-class-component": "^8.0.0-beta.4",
-    "@vue/vue3-jest": "^28.0.0",
     "vue-property-decorator": "^10.0.0-rc.3"
   }
 }

--- a/e2e/3.x/typescript-with-babel/package.json
+++ b/e2e/3.x/typescript-with-babel/package.json
@@ -12,11 +12,10 @@
   "devDependencies": {
     "@babel/core": "^7.9.0",
     "@babel/preset-env": "^7.9.0",
+    "@vue/vue3-jest": "^28.0.0",
     "jest": "^28.0.2",
     "jest-environment-jsdom": "28.0.2",
-    "ts-jest": "^28.0.1",
-    "typescript": "^4.6.4",
-    "@vue/vue3-jest": "^28.0.0"
+    "typescript": "^4.6.4"
   },
   "jest": {
     "testEnvironment": "jsdom",

--- a/e2e/3.x/typescript-with-compiler-options/package.json
+++ b/e2e/3.x/typescript-with-compiler-options/package.json
@@ -11,11 +11,11 @@
   },
   "devDependencies": {
     "@types/jest": "16.0.10",
+    "@vue/vue3-jest": "^28.0.0",
     "jest": "^28.0.2",
     "jest-environment-jsdom": "28.0.2",
     "ts-jest": "^28.0.1",
-    "typescript": "^4.6.4",
-    "@vue/vue3-jest": "^28.0.0"
+    "typescript": "^4.6.4"
   },
   "jest": {
     "testEnvironment": "jsdom",

--- a/e2e/3.x/typescript/package.json
+++ b/e2e/3.x/typescript/package.json
@@ -11,11 +11,11 @@
   },
   "devDependencies": {
     "@types/jest": "16.0.10",
+    "@vue/vue3-jest": "^28.0.0",
     "jest": "^28.0.2",
     "jest-environment-jsdom": "28.0.2",
     "ts-jest": "^28.0.1",
-    "typescript": "^4.6.4",
-    "@vue/vue3-jest": "^28.0.0"
+    "typescript": "^4.6.4"
   },
   "jest": {
     "testEnvironment": "jsdom",

--- a/packages/vue2-jest/lib/transformers/typescript.js
+++ b/packages/vue2-jest/lib/transformers/typescript.js
@@ -1,9 +1,9 @@
 const ensureRequire = require('../ensure-require')
 const babelJest = require('babel-jest').default
 const {
-  getTsJestConfig,
   stripInlineSourceMap,
   getCustomTransformer,
+  getTypeScriptConfig,
   getVueJestConfig
 } = require('../utils')
 
@@ -12,7 +12,7 @@ module.exports = scriptLang => ({
     ensureRequire('typescript', ['typescript'])
     const typescript = require('typescript')
     const vueJestConfig = getVueJestConfig(config)
-    const tsconfig = getTsJestConfig(config)
+    const tsconfig = getTypeScriptConfig(vueJestConfig.tsConfig)
 
     const res = typescript.transpileModule(scriptContent, {
       ...tsconfig,

--- a/packages/vue2-jest/lib/utils.js
+++ b/packages/vue2-jest/lib/utils.js
@@ -68,15 +68,6 @@ const getBabelOptions = function loadBabelOptions(filename, options = {}) {
   return loadPartialConfig(opts).options
 }
 
-const getTsJestConfig = function getTsJestConfig(config) {
-  const { ConfigSet } = require('ts-jest/dist/legacy/config/config-set')
-  const configSet = new ConfigSet(config.config)
-  var tsConfig = configSet.typescript || configSet.parsedTsConfig
-  return {
-    compilerOptions: { ...tsConfig.options, module: 'commonjs' }
-  }
-}
-
 /**
  * Load TypeScript config from tsconfig.json.
  * @param {string | undefined} path tsconfig.json file path (default: root)
@@ -173,7 +164,6 @@ module.exports = {
   throwError,
   logResultErrors,
   getCustomTransformer,
-  getTsJestConfig,
   getTypeScriptConfig,
   getBabelOptions,
   getVueJestConfig,

--- a/packages/vue2-jest/lib/utils.js
+++ b/packages/vue2-jest/lib/utils.js
@@ -76,10 +76,9 @@ const getBabelOptions = function loadBabelOptions(filename, options = {}) {
 const getTypeScriptConfig = function getTypeScriptConfig(path) {
   const tsconfig = loadTsConfigSync(process.cwd(), path || '')
   if (!tsconfig.path) {
-    info(`Not found tsconfig.json.`)
+    warn(`Not found tsconfig.json.`)
     return null
   }
-  info(`Loaded TypeScript config from "${tsconfig.path}".`)
   const compilerOptions =
     (tsconfig.config && tsconfig.config.compilerOptions) || {}
 

--- a/packages/vue2-jest/lib/utils.js
+++ b/packages/vue2-jest/lib/utils.js
@@ -89,6 +89,7 @@ const getTypeScriptConfig = function getTypeScriptConfig(path) {
 
 function isValidTransformer(transformer) {
   return (
+    isFunction(transformer.createTransformer) ||
     isFunction(transformer.process) ||
     isFunction(transformer.postprocess) ||
     isFunction(transformer.preprocess)
@@ -121,12 +122,13 @@ const getCustomTransformer = function getCustomTransformer(
 
   if (!isValidTransformer(transformer)) {
     throwError(
-      `transformer must contain at least one process, preprocess, or ` +
-        `postprocess method`
+      `transformer must contain at least one createTransformer(), process(), preprocess(), or postprocess() method`
     )
   }
 
-  return transformer
+  return isFunction(transformer.createTransformer)
+    ? transformer.createTransformer()
+    : transformer
 }
 
 const throwError = function error(msg) {

--- a/packages/vue2-jest/lib/utils.js
+++ b/packages/vue2-jest/lib/utils.js
@@ -1,5 +1,6 @@
 const constants = require('./constants')
 const loadPartialConfig = require('@babel/core').loadPartialConfig
+const { loadSync: loadTsConfigSync } = require('tsconfig')
 const chalk = require('chalk')
 const path = require('path')
 const fs = require('fs')
@@ -73,6 +74,26 @@ const getTsJestConfig = function getTsJestConfig(config) {
   var tsConfig = configSet.typescript || configSet.parsedTsConfig
   return {
     compilerOptions: { ...tsConfig.options, module: 'commonjs' }
+  }
+}
+
+/**
+ * Load TypeScript config from tsconfig.json.
+ * @param {string | undefined} path tsconfig.json file path (default: root)
+ * @returns {import('typescript').TranspileOptions | null} TypeScript compilerOptions or null
+ */
+const getTypeScriptConfig = function getTypeScriptConfig(path) {
+  const tsconfig = loadTsConfigSync(process.cwd(), path || '')
+  if (!tsconfig.path) {
+    info(`Not found tsconfig.json.`)
+    return null
+  }
+  info(`Loaded TypeScript config from "${tsconfig.path}".`)
+  const compilerOptions =
+    (tsconfig.config && tsconfig.config.compilerOptions) || {}
+
+  return {
+    compilerOptions: { ...compilerOptions, module: 'commonjs' }
   }
 }
 
@@ -153,6 +174,7 @@ module.exports = {
   logResultErrors,
   getCustomTransformer,
   getTsJestConfig,
+  getTypeScriptConfig,
   getBabelOptions,
   getVueJestConfig,
   transformContent,

--- a/packages/vue2-jest/package.json
+++ b/packages/vue2-jest/package.json
@@ -55,7 +55,8 @@
     "@vue/component-compiler-utils": "^3.1.0",
     "chalk": "^2.1.0",
     "css-tree": "^2.0.1",
-    "source-map": "0.5.6"
+    "source-map": "0.5.6",
+    "tsconfig": "^7.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/vue2-jest/package.json
+++ b/packages/vue2-jest/package.json
@@ -32,7 +32,6 @@
     "conventional-changelog": "^1.1.5",
     "jest": "^28.0.2",
     "semantic-release": "^15.13.2",
-    "ts-jest": "^28.0.1",
     "typescript": "^4.6.4",
     "vue": "^2.4.2",
     "vue-template-compiler": "^2.4.2"
@@ -41,12 +40,12 @@
     "@babel/core": "7.x",
     "babel-jest": ">= 28 < 29",
     "jest": "28.x",
-    "ts-jest": ">= 28 < 29",
+    "typescript": ">= 4.3",
     "vue": "^2.x",
     "vue-template-compiler": "^2.x"
   },
   "peerDependenciesMeta": {
-    "ts-jest": {
+    "typescript": {
       "optional": true
     }
   },

--- a/packages/vue3-jest/lib/process.js
+++ b/packages/vue3-jest/lib/process.js
@@ -6,8 +6,8 @@ const typescriptTransformer = require('./transformers/typescript')
 const coffeescriptTransformer = require('./transformers/coffee')
 const _processStyle = require('./process-style')
 const processCustomBlocks = require('./process-custom-blocks')
+const getTypeScriptConfig = require('./utils').getTypeScriptConfig
 const getVueJestConfig = require('./utils').getVueJestConfig
-const getTsJestConfig = require('./utils').getTsJestConfig
 const logResultErrors = require('./utils').logResultErrors
 const stripInlineSourceMap = require('./utils').stripInlineSourceMap
 const getCustomTransformer = require('./utils').getCustomTransformer
@@ -118,7 +118,7 @@ function processTemplate(descriptor, filename, config) {
 
   logResultErrors(result)
 
-  const tsconfig = getTsJestConfig(config)
+  const tsconfig = getTypeScriptConfig(vueJestConfig.tsConfig)
 
   if (tsconfig) {
     // they are using TypeScript.

--- a/packages/vue3-jest/lib/transformers/typescript.js
+++ b/packages/vue3-jest/lib/transformers/typescript.js
@@ -1,9 +1,9 @@
 const ensureRequire = require('../ensure-require')
 const babelJest = require('babel-jest').default
 const {
-  getTsJestConfig,
   stripInlineSourceMap,
   getCustomTransformer,
+  getTypeScriptConfig,
   getVueJestConfig
 } = require('../utils')
 
@@ -12,7 +12,7 @@ module.exports = {
     ensureRequire('typescript', ['typescript'])
     const typescript = require('typescript')
     const vueJestConfig = getVueJestConfig(config)
-    const tsconfig = getTsJestConfig(config)
+    const tsconfig = getTypeScriptConfig(vueJestConfig.tsConfig)
 
     const res = typescript.transpileModule(scriptContent, {
       ...tsconfig,

--- a/packages/vue3-jest/lib/utils.js
+++ b/packages/vue3-jest/lib/utils.js
@@ -1,6 +1,9 @@
 const constants = require('./constants')
 const loadPartialConfig = require('@babel/core').loadPartialConfig
-const { resolveSync: resolveTsConfigSync } = require('tsconfig')
+const {
+  loadSync: loadTsConfigSync,
+  resolveSync: resolveTsConfigSync
+} = require('tsconfig')
 const chalk = require('chalk')
 const path = require('path')
 const fs = require('fs')
@@ -84,6 +87,27 @@ const getTsJestConfig = function getTsJestConfig(config) {
   }
 }
 
+/**
+ * Load TypeScript config from tsconfig.json.
+ * @param {string | undefined} path tsconfig.json file path (default: root)
+ * @returns {import('typescript').TranspileOptions | null} TypeScript compilerOptions or null
+ */
+const getTypeScriptConfig = function getTypeScriptConfig(path) {
+  const tsconfig = loadTsConfigSync(process.cwd(), path || '')
+  if (!tsconfig.path) {
+    info(`Not found tsconfig.json.`)
+    return null
+  }
+  info(`Loaded TypeScript config from "${tsconfig.path}".`)
+  const compilerOptions =
+    (tsconfig.config && tsconfig.config.compilerOptions) || {}
+
+  // Force es5 to prevent const vue_1 = require('vue') from conflicting
+  return {
+    compilerOptions: { ...compilerOptions, target: 'es5', module: 'commonjs' }
+  }
+}
+
 function isValidTransformer(transformer) {
   return (
     isFunction(transformer.process) ||
@@ -162,6 +186,7 @@ module.exports = {
   logResultErrors,
   getCustomTransformer,
   getTsJestConfig,
+  getTypeScriptConfig,
   getBabelOptions,
   getVueJestConfig,
   transformContent,

--- a/packages/vue3-jest/lib/utils.js
+++ b/packages/vue3-jest/lib/utils.js
@@ -1,9 +1,6 @@
 const constants = require('./constants')
 const loadPartialConfig = require('@babel/core').loadPartialConfig
-const {
-  loadSync: loadTsConfigSync,
-  resolveSync: resolveTsConfigSync
-} = require('tsconfig')
+const { loadSync: loadTsConfigSync } = require('tsconfig')
 const chalk = require('chalk')
 const path = require('path')
 const fs = require('fs')
@@ -69,22 +66,6 @@ const getBabelOptions = function loadBabelOptions(filename, options = {}) {
     sourceMaps: 'both'
   })
   return loadPartialConfig(opts).options
-}
-
-const getTsJestConfig = function getTsJestConfig(config) {
-  const tsConfigPath = getVueJestConfig(config).tsConfig || ''
-  const isUsingTs = resolveTsConfigSync(process.cwd(), tsConfigPath)
-  if (!isUsingTs) {
-    return null
-  }
-
-  const { ConfigSet } = require('ts-jest/dist/legacy/config/config-set')
-  const configSet = new ConfigSet(config.config)
-  const tsConfig = configSet.typescript || configSet.parsedTsConfig
-  // Force es5 to prevent const vue_1 = require('vue') from conflicting
-  return {
-    compilerOptions: { ...tsConfig.options, target: 'es5', module: 'commonjs' }
-  }
 }
 
 /**
@@ -185,7 +166,6 @@ module.exports = {
   throwError,
   logResultErrors,
   getCustomTransformer,
-  getTsJestConfig,
   getTypeScriptConfig,
   getBabelOptions,
   getVueJestConfig,

--- a/packages/vue3-jest/lib/utils.js
+++ b/packages/vue3-jest/lib/utils.js
@@ -90,6 +90,7 @@ const getTypeScriptConfig = function getTypeScriptConfig(path) {
 
 function isValidTransformer(transformer) {
   return (
+    isFunction(transformer.createTransformer) ||
     isFunction(transformer.process) ||
     isFunction(transformer.postprocess) ||
     isFunction(transformer.preprocess)
@@ -123,12 +124,13 @@ const getCustomTransformer = function getCustomTransformer(
 
   if (!isValidTransformer(transformer)) {
     throwError(
-      `transformer must contain at least one process, preprocess, or ` +
-        `postprocess method`
+      `transformer must contain at least one createTransformer(), process(), preprocess(), or postprocess() method`
     )
   }
 
-  return transformer
+  return isFunction(transformer.createTransformer)
+    ? transformer.createTransformer()
+    : transformer
 }
 
 const throwError = function error(msg) {

--- a/packages/vue3-jest/lib/utils.js
+++ b/packages/vue3-jest/lib/utils.js
@@ -76,10 +76,9 @@ const getBabelOptions = function loadBabelOptions(filename, options = {}) {
 const getTypeScriptConfig = function getTypeScriptConfig(path) {
   const tsconfig = loadTsConfigSync(process.cwd(), path || '')
   if (!tsconfig.path) {
-    info(`Not found tsconfig.json.`)
+    warn(`Not found tsconfig.json.`)
     return null
   }
-  info(`Loaded TypeScript config from "${tsconfig.path}".`)
   const compilerOptions =
     (tsconfig.config && tsconfig.config.compilerOptions) || {}
 

--- a/packages/vue3-jest/package.json
+++ b/packages/vue3-jest/package.json
@@ -31,7 +31,6 @@
     "jest": "^28.0.2",
     "jest-cli": "^28.0.2",
     "semantic-release": "^15.13.2",
-    "ts-jest": "^28.0.1",
     "typescript": "^4.6.4",
     "vue": "^3.2.22"
   },
@@ -39,14 +38,10 @@
     "@babel/core": "7.x",
     "babel-jest": "28.x",
     "jest": "28.x",
-    "ts-jest": "28.x",
     "typescript": ">= 4.3",
     "vue": "^3.0.0-0"
   },
   "peerDependenciesMeta": {
-    "ts-jest": {
-      "optional": true
-    },
     "typescript": {
       "optional": true
     }


### PR DESCRIPTION
**:warning:This PR contains BREAKING CHANGES!!:warning:**

This PR conflicts with #468, so I set as draft.
Resolve #171, #431

## Changes
- Use `tsconfig` package to load TypeScript config.
- Remove `ts-jest` peerDependencies.

### Breaking Changes
- Some tests will break that depend on `ts-jest` config.

```javascript
// jest.config.js
module.exports = {
  globals: {
    "ts-jest": {...} // Not loaded during transforming Vue (use tsconfig.json instead)
  }
}
```

