### PR TITLE
chore: release Jest 28 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,18 +6,23 @@ Jest transformer for Vue Single File Components.
 
 Since we need to support a variety of Vue and Jest versions, vue-jest doesn't follow semantic versioning.
 
-| Vue version | Jest Version      | Package             |
-| ----------- | ----------------- | ------------------- |
-| Vue 2       | Jest 26 and below | `vue-jest@4`        |
-| Vue 3       | Jest 26 and below | `vue-jest@5`        |
-| Vue 2       | Jest 27 and above | `@vue/vue2-jest@xx` |
-| Vue 3       | Jest 27 and above | `@vue/vue3-jest@xx` |
-
-**xx**: Major version of Jest
+| Vue version | Jest Version      | npm Package         | Branch |
+| ----------- | ----------------- | ------------------- | ------ |
+| Vue 2       | Jest 26 and below | `vue-jest@4`        |        |
+| Vue 3       | Jest 26 and below | `vue-jest@5`        |        |
+| Vue 2       | Jest 27 and above | `@vue/vue2-jest@27` | 27.x   |
+| Vue 3       | Jest 27 and above | `@vue/vue3-jest@27` | 27.x   |
+| Vue 2       | Jest 28 and above | `@vue/vue2-jest@28` | 28.x   |
+| Vue 3       | Jest 27 and above | `@vue/vue3-jest@28` | 28.x   |
 
 ```bash
-npm install --save-dev @vue/vue2-jest # (use the appropriate version)
-yarn add @vue/vue2-jest --dev
+# Vue 2
+npm install --save-dev @vue/vue2-jest@28 # (use the appropriate version)
+yarn add @vue/vue2-jest@28 --dev
+
+# Vue 3
+npm install --save-dev @vue/vue3-jest@28 # (use the appropriate version)
+yarn add @vue/vue3-jest@28 --dev
 ```
 
 ## Setup

--- a/e2e/2.x/babel-in-package/package.json
+++ b/e2e/2.x/babel-in-package/package.json
@@ -16,7 +16,7 @@
     "@babel/preset-env": "^7.9.0",
     "@vue/babel-preset-jsx": "^1.2.4",
     "@vue/test-utils": "^1.1.0",
-    "@vue/vue2-jest": "~27.0.0-alpha.1",
+    "@vue/vue2-jest": "^28.0.0",
     "coffeescript": "^2.3.2",
     "jest": "28.x",
     "jest-environment-jsdom": "28.0.2",

--- a/e2e/2.x/basic/package.json
+++ b/e2e/2.x/basic/package.json
@@ -25,7 +25,7 @@
     "sass": "^1.23.7",
     "ts-jest": "^28.0.1",
     "typescript": "^4.6.4",
-    "@vue/vue2-jest": "~27.0.0-alpha.1"
+    "@vue/vue2-jest": "^28.0.0"
   },
   "jest": {
     "testEnvironment": "jsdom",

--- a/e2e/2.x/custom-transformers/package.json
+++ b/e2e/2.x/custom-transformers/package.json
@@ -20,7 +20,7 @@
     "postcss": "^7.0.13",
     "postcss-color-function": "^4.0.1",
     "sass": "^1.23.7",
-    "@vue/vue2-jest": "~27.0.0-alpha.1"
+    "@vue/vue2-jest": "^28.0.0"
   },
   "jest": {
     "testEnvironment": "jsdom",

--- a/e2e/2.x/style/package.json
+++ b/e2e/2.x/style/package.json
@@ -19,7 +19,7 @@
     "postcss": "^7.0.13",
     "sass": "^1.23.7",
     "stylus": "^0.54.5",
-    "@vue/vue2-jest": "~27.0.0-alpha.1"
+    "@vue/vue2-jest": "^28.0.0"
   },
   "jest": {
     "testEnvironment": "jsdom",

--- a/e2e/3.x/babel-in-package/package.json
+++ b/e2e/3.x/babel-in-package/package.json
@@ -17,7 +17,7 @@
     "jest-environment-jsdom": "28.0.2",
     "ts-jest": "^28.0.1",
     "typescript": "^4.6.4",
-    "@vue/vue3-jest": "^27.0.0-alpha.1"
+    "@vue/vue3-jest": "^28.0.0"
   },
   "jest": {
     "testEnvironment": "jsdom",

--- a/e2e/3.x/basic/package.json
+++ b/e2e/3.x/basic/package.json
@@ -23,7 +23,7 @@
     "ts-jest": "^28.0.1",
     "typescript": "^4.6.4",
     "vue-class-component": "^8.0.0-beta.4",
-    "@vue/vue3-jest": "^27.0.0-alpha.1",
+    "@vue/vue3-jest": "^28.0.0",
     "vue-property-decorator": "^10.0.0-rc.3"
   }
 }

--- a/e2e/3.x/custom-block/package.json
+++ b/e2e/3.x/custom-block/package.json
@@ -13,7 +13,7 @@
     "@babel/core": "^7.9.0",
     "@babel/preset-env": "^7.9.0",
     "@vue/compiler-sfc": "^3.0.3",
-    "@vue/vue3-jest": "^27.0.0-alpha.1",
+    "@vue/vue3-jest": "^28.0.0",
     "jest": "^28.0.2",
     "jest-environment-jsdom": "28.0.2"
   },

--- a/e2e/3.x/custom-transformers/package.json
+++ b/e2e/3.x/custom-transformers/package.json
@@ -13,7 +13,7 @@
     "@babel/core": "^7.9.0",
     "@babel/preset-env": "^7.9.0",
     "@vue/test-utils": "^2.0.0-rc.10",
-    "@vue/vue3-jest": "^27.0.0-alpha.1",
+    "@vue/vue3-jest": "^28.0.0",
     "babel-jest": "^28.0.2",
     "css-tree": "^2.0.1",
     "jest": "^28.0.2",

--- a/e2e/3.x/javascript/package.json
+++ b/e2e/3.x/javascript/package.json
@@ -15,7 +15,7 @@
     "coffeescript": "^2.3.2",
     "jest": "^28.0.2",
     "jest-environment-jsdom": "28.0.2",
-    "@vue/vue3-jest": "^27.0.0-alpha.1"
+    "@vue/vue3-jest": "^28.0.0"
   },
   "jest": {
     "testEnvironment": "jsdom",

--- a/e2e/3.x/style/package.json
+++ b/e2e/3.x/style/package.json
@@ -19,7 +19,7 @@
     "postcss": "^7.0.13",
     "sass": "^1.23.7",
     "stylus": "^0.54.5",
-    "@vue/vue3-jest": "^27.0.0-alpha.1"
+    "@vue/vue3-jest": "^28.0.0"
   },
   "jest": {
     "testEnvironment": "jsdom",

--- a/e2e/3.x/typescript-with-babel/package.json
+++ b/e2e/3.x/typescript-with-babel/package.json
@@ -16,7 +16,7 @@
     "jest-environment-jsdom": "28.0.2",
     "ts-jest": "^28.0.1",
     "typescript": "^4.6.4",
-    "@vue/vue3-jest": "^27.0.0-alpha.1"
+    "@vue/vue3-jest": "^28.0.0"
   },
   "jest": {
     "testEnvironment": "jsdom",

--- a/e2e/3.x/typescript-with-compiler-options/package.json
+++ b/e2e/3.x/typescript-with-compiler-options/package.json
@@ -15,7 +15,7 @@
     "jest-environment-jsdom": "28.0.2",
     "ts-jest": "^28.0.1",
     "typescript": "^4.6.4",
-    "@vue/vue3-jest": "^27.0.0-alpha.1"
+    "@vue/vue3-jest": "^28.0.0"
   },
   "jest": {
     "testEnvironment": "jsdom",

--- a/e2e/3.x/typescript/package.json
+++ b/e2e/3.x/typescript/package.json
@@ -15,7 +15,7 @@
     "jest-environment-jsdom": "28.0.2",
     "ts-jest": "^28.0.1",
     "typescript": "^4.6.4",
-    "@vue/vue3-jest": "^27.0.0-alpha.1"
+    "@vue/vue3-jest": "^28.0.0"
   },
   "jest": {
     "testEnvironment": "jsdom",

--- a/packages/vue2-jest/package.json
+++ b/packages/vue2-jest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vue/vue2-jest",
-  "version": "27.0.0",
+  "version": "28.0.0",
   "description": "Jest transformer for Vue 2",
   "main": "lib/index.js",
   "files": [

--- a/packages/vue3-jest/package.json
+++ b/packages/vue3-jest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vue/vue3-jest",
-  "version": "27.0.0",
+  "version": "28.0.0",
   "description": "Jest Vue transform",
   "main": "lib/index.js",
   "files": [


### PR DESCRIPTION
Jest 28 is not the main version on npm, so we will follow suit and make vue2-jest@28 and vue2-jest@28 the main version, too.

You can still get the Jest 27 version with `yarn add vue3-jest@27`.