### PR TITLE
feat: support <script setup> in Vue 2.7

### DIFF
--- a/e2e/2.x/babel-in-package/package.json
+++ b/e2e/2.x/babel-in-package/package.json
@@ -8,8 +8,8 @@
   },
   "dependencies": {
     "source-map": "0.5.6",
-    "vue": "^2.7.2",
-    "vue-template-compiler": "^2.7.2"
+    "vue": "^2.7.7",
+    "vue-template-compiler": "^2.7.7"
   },
   "devDependencies": {
     "@babel/core": "^7.9.0",

--- a/e2e/2.x/babel-in-package/package.json
+++ b/e2e/2.x/babel-in-package/package.json
@@ -8,8 +8,8 @@
   },
   "dependencies": {
     "source-map": "0.5.6",
-    "vue": "^2.5.21",
-    "vue-template-compiler": "^2.5.21"
+    "vue": "^2.7.2",
+    "vue-template-compiler": "^2.7.2"
   },
   "devDependencies": {
     "@babel/core": "^7.9.0",

--- a/e2e/2.x/basic/components/ScriptSetup.vue
+++ b/e2e/2.x/basic/components/ScriptSetup.vue
@@ -1,0 +1,20 @@
+<template>
+  <div>
+    <button @click="increase">Count: {{ num }}</button>
+    <Basic />
+    <span>{{ msg }}</span>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { ref } from 'vue'
+import Basic from './Basic.vue'
+
+const num = ref(5)
+const greet = () => console.log('greet')
+const increase = () => {
+  greet()
+  num.value++
+}
+const msg = 'hello world'
+</script>

--- a/e2e/2.x/basic/package.json
+++ b/e2e/2.x/basic/package.json
@@ -7,8 +7,8 @@
     "test": "jest --no-cache --coverage test.js"
   },
   "dependencies": {
-    "vue": "^2.5.21",
-    "vue-template-compiler": "^2.5.21"
+    "vue": "^2.7.2",
+    "vue-template-compiler": "^2.7.2"
   },
   "devDependencies": {
     "@babel/core": "^7.9.0",

--- a/e2e/2.x/basic/package.json
+++ b/e2e/2.x/basic/package.json
@@ -7,8 +7,8 @@
     "test": "jest --no-cache --coverage test.js"
   },
   "dependencies": {
-    "vue": "^2.7.2",
-    "vue-template-compiler": "^2.7.2"
+    "vue": "^2.7.7",
+    "vue-template-compiler": "^2.7.7"
   },
   "devDependencies": {
     "@babel/core": "^7.9.0",

--- a/e2e/2.x/basic/test.js
+++ b/e2e/2.x/basic/test.js
@@ -20,6 +20,7 @@ import PugRelative from './components/PugRelativeExtends.vue'
 import Jsx from './components/Jsx.vue'
 import Constructor from './components/Constructor.vue'
 import { compileStyle } from '@vue/component-compiler-utils'
+import ScriptSetup from './components/ScriptSetup'
 jest.mock('@vue/component-compiler-utils', () => ({
   ...jest.requireActual('@vue/component-compiler-utils'),
   compileStyle: jest.fn(() => ({ errors: [], code: '' }))
@@ -154,6 +155,12 @@ test('supports relative paths when extending templates from .pug files', () => {
 test('processes SFC with no template', () => {
   const wrapper = mount(RenderFunction)
   expect(wrapper.element.tagName).toBe('SECTION')
+})
+
+test('processes SFC with <script setup>', () => {
+  const wrapper = mount(ScriptSetup)
+  expect(wrapper.html()).toContain('Count: 5')
+  expect(wrapper.html()).toContain('Welcome to Your Vue.js App')
 })
 
 test('should pass properly "styleOptions" into "preprocessOptions"', () => {

--- a/e2e/2.x/custom-transformers/package.json
+++ b/e2e/2.x/custom-transformers/package.json
@@ -7,8 +7,8 @@
     "test": "jest --no-cache --coverage test.js"
   },
   "dependencies": {
-    "vue": "^2.5.21",
-    "vue-template-compiler": "^2.5.21"
+    "vue": "^2.7.2",
+    "vue-template-compiler": "^2.7.2"
   },
   "devDependencies": {
     "@babel/core": "^7.9.0",

--- a/e2e/2.x/custom-transformers/package.json
+++ b/e2e/2.x/custom-transformers/package.json
@@ -7,8 +7,8 @@
     "test": "jest --no-cache --coverage test.js"
   },
   "dependencies": {
-    "vue": "^2.7.2",
-    "vue-template-compiler": "^2.7.2"
+    "vue": "^2.7.7",
+    "vue-template-compiler": "^2.7.7"
   },
   "devDependencies": {
     "@babel/core": "^7.9.0",

--- a/e2e/2.x/sass-importer/entry/package.json
+++ b/e2e/2.x/sass-importer/entry/package.json
@@ -7,8 +7,8 @@
     "test": "jest --no-cache --coverage test.js"
   },
   "dependencies": {
-    "vue": "^2.5.21",
-    "vue-template-compiler": "^2.5.21",
+    "vue": "^2.7.2",
+    "vue-template-compiler": "^2.7.2",
     "vue2-sass-importer-lib": "file:../lib",
     "vue2-sass-importer-sass-lib": "file:../sass-lib-v2"
   },

--- a/e2e/2.x/sass-importer/entry/package.json
+++ b/e2e/2.x/sass-importer/entry/package.json
@@ -7,8 +7,8 @@
     "test": "jest --no-cache --coverage test.js"
   },
   "dependencies": {
-    "vue": "^2.7.2",
-    "vue-template-compiler": "^2.7.2",
+    "vue": "^2.7.7",
+    "vue-template-compiler": "^2.7.7",
     "vue2-sass-importer-lib": "file:../lib",
     "vue2-sass-importer-sass-lib": "file:../sass-lib-v2"
   },

--- a/e2e/2.x/sass-importer/lib/package.json
+++ b/e2e/2.x/sass-importer/lib/package.json
@@ -14,6 +14,6 @@
     "vue2-sass-importer-sass-lib": "file:../sass-lib-v1"
   },
   "peerDependencies": {
-    "vue": "^2.7.2"
+    "vue": "^2.7.7"
   }
 }

--- a/e2e/2.x/sass-importer/lib/package.json
+++ b/e2e/2.x/sass-importer/lib/package.json
@@ -14,6 +14,6 @@
     "vue2-sass-importer-sass-lib": "file:../sass-lib-v1"
   },
   "peerDependencies": {
-    "vue": "^2.5.21"
+    "vue": "^2.7.2"
   }
 }

--- a/e2e/2.x/style/package.json
+++ b/e2e/2.x/style/package.json
@@ -7,8 +7,8 @@
     "test": "node setup.js && jest --no-cache test.js"
   },
   "dependencies": {
-    "vue": "^2.7.2",
-    "vue-template-compiler": "^2.7.2"
+    "vue": "^2.7.7",
+    "vue-template-compiler": "^2.7.7"
   },
   "devDependencies": {
     "@babel/core": "^7.9.0",

--- a/e2e/2.x/style/package.json
+++ b/e2e/2.x/style/package.json
@@ -7,8 +7,8 @@
     "test": "node setup.js && jest --no-cache test.js"
   },
   "dependencies": {
-    "vue": "^2.5.21",
-    "vue-template-compiler": "^2.5.21"
+    "vue": "^2.7.2",
+    "vue-template-compiler": "^2.7.2"
   },
   "devDependencies": {
     "@babel/core": "^7.9.0",

--- a/packages/vue2-jest/lib/generate-code.js
+++ b/packages/vue2-jest/lib/generate-code.js
@@ -4,6 +4,7 @@ const splitRE = /\r?\n/g
 
 module.exports = function generateCode(
   scriptResult,
+  scriptSetupResult,
   templateResult,
   stylesResult,
   customBlocksResult,
@@ -13,8 +14,9 @@ module.exports = function generateCode(
   let renderFnStartLine
   let renderFnEndLine
 
-  if (scriptResult) {
-    output += `${scriptResult.code};\n`
+  const finalScriptResult = scriptResult || scriptSetupResult
+  if (finalScriptResult) {
+    output += `${finalScriptResult.code};\n`
   } else {
     output +=
       `Object.defineProperty(exports, "__esModule", {\n` +

--- a/packages/vue2-jest/lib/generate-source-map.js
+++ b/packages/vue2-jest/lib/generate-source-map.js
@@ -4,6 +4,7 @@ const splitRE = /\r?\n/g
 
 module.exports = function generateSourceMap(
   scriptResult,
+  scriptSetupResult,
   src,
   filename,
   renderFnStartLine,
@@ -20,10 +21,13 @@ module.exports = function generateSourceMap(
   const srcContent = scriptFromExternalSrc ? scriptResult.externalSrc : src
 
   map.setSourceContent(file, srcContent)
-  if (scriptResult) {
+
+  const finalScriptResult = scriptResult || scriptSetupResult
+  if (finalScriptResult) {
     let inputMapConsumer =
-      scriptResult.map && new sourceMap.SourceMapConsumer(scriptResult.map)
-    scriptResult.code.split(splitRE).forEach(function(line, index) {
+      finalScriptResult.map &&
+      new sourceMap.SourceMapConsumer(finalScriptResult.map)
+    finalScriptResult.code.split(splitRE).forEach(function(line, index) {
       let ln = index + 1
       let originalLine = inputMapConsumer
         ? inputMapConsumer.originalPositionFor({ line: ln, column: 0 }).line

--- a/packages/vue2-jest/lib/map-lines.js
+++ b/packages/vue2-jest/lib/map-lines.js
@@ -1,0 +1,55 @@
+const { SourceMapGenerator, SourceMapConsumer } = require('source-map')
+
+// based on @vue/compiler-sfc mapLines
+module.exports = function mapLines(oldMap, newMap) {
+  if (!oldMap) return newMap
+  if (!newMap) return oldMap
+
+  const oldMapConsumer = new SourceMapConsumer(oldMap)
+  const newMapConsumer = new SourceMapConsumer(newMap)
+  const mergedMapGenerator = new SourceMapGenerator()
+
+  newMapConsumer.eachMapping(m => {
+    if (m.originalLine == null) {
+      return
+    }
+
+    const origPosInOldMap = oldMapConsumer.originalPositionFor({
+      line: m.originalLine,
+      column: m.originalColumn
+    })
+
+    if (origPosInOldMap.source == null) {
+      return
+    }
+
+    mergedMapGenerator.addMapping({
+      generated: {
+        line: m.generatedLine,
+        column: m.generatedColumn
+      },
+      original: {
+        line: origPosInOldMap.line, // map line
+        // use current column, since the oldMap produced by @vue/compiler-sfc
+        // does not
+        column: m.originalColumn
+      },
+      source: origPosInOldMap.source,
+      name: origPosInOldMap.name
+    })
+  })
+
+  // source-map's type definition is incomplete
+  const generator = mergedMapGenerator
+  oldMapConsumer.sources.forEach(sourceFile => {
+    generator._sources.add(sourceFile)
+    const sourceContent = oldMapConsumer.sourceContentFor(sourceFile)
+    if (sourceContent != null) {
+      mergedMapGenerator.setSourceContent(sourceFile, sourceContent)
+    }
+  })
+
+  generator._sourceRoot = oldMap.sourceRoot
+  generator._file = oldMap.file
+  return generator.toJSON()
+}

--- a/packages/vue2-jest/lib/process.js
+++ b/packages/vue2-jest/lib/process.js
@@ -164,8 +164,8 @@ module.exports = function(src, filename, config) {
   )
 
   const map = generateSourceMap(
-    // TODO Add scriptSetup
     scriptResult,
+    scriptSetupResult,
     src,
     filename,
     output.renderFnStartLine,

--- a/packages/vue2-jest/lib/process.js
+++ b/packages/vue2-jest/lib/process.js
@@ -103,7 +103,6 @@ function processTemplate(descriptor, filename, config) {
     bindings,
     ...userTemplateCompilerOptions,
     compilerOptions: {
-      bindingMetadata: bindings,
       optimize: false,
       ...userTemplateCompilerOptions.compilerOptions
     }

--- a/packages/vue2-jest/lib/process.js
+++ b/packages/vue2-jest/lib/process.js
@@ -53,7 +53,6 @@ function processScriptSetup(descriptor, filePath, config) {
   const vueJestConfig = getVueJestConfig(config)
   const content = compileScript(descriptor, {
     id: filePath,
-    refTransform: true,
     ...vueJestConfig.compilerOptions
   })
   const contentMap = mapLines(descriptor.scriptSetup.map, content.map)
@@ -86,7 +85,6 @@ function processTemplate(descriptor, filename, config) {
   if (scriptSetup) {
     const scriptSetupResult = compileScript(descriptor, {
       id: filename,
-      refTransform: true,
       ...vueJestConfig.compilerOptions
     })
     bindings = scriptSetupResult.bindings

--- a/packages/vue2-jest/lib/process.js
+++ b/packages/vue2-jest/lib/process.js
@@ -11,8 +11,9 @@ const stripInlineSourceMap = require('./utils').stripInlineSourceMap
 const getCustomTransformer = require('./utils').getCustomTransformer
 const loadSrc = require('./utils').loadSrc
 const babelTransformer = require('babel-jest').default
-const compilerUtils = require('@vue/component-compiler-utils')
+const { parse, compileTemplate, compileScript } = require('@vue/compiler-sfc')
 const generateCode = require('./generate-code')
+const mapLines = require('./map-lines')
 
 function resolveTransformer(lang = 'js', vueJestConfig) {
   const transformer = getCustomTransformer(vueJestConfig['transform'], lang)
@@ -45,7 +46,32 @@ function processScript(scriptPart, filePath, config) {
   return result
 }
 
-function processTemplate(template, filename, config) {
+function processScriptSetup(descriptor, filePath, config) {
+  if (!descriptor.scriptSetup) {
+    return null
+  }
+  const vueJestConfig = getVueJestConfig(config)
+  const content = compileScript(descriptor, {
+    id: filePath,
+    refTransform: true,
+    ...vueJestConfig.compilerOptions
+  })
+  const contentMap = mapLines(descriptor.scriptSetup.map, content.map)
+
+  const transformer = resolveTransformer(
+    descriptor.scriptSetup.lang,
+    vueJestConfig
+  )
+
+  const result = transformer.process(content.content, filePath, config)
+  result.map = mapLines(contentMap, result.map)
+
+  return result
+}
+
+function processTemplate(descriptor, filename, config) {
+  const { template, scriptSetup } = descriptor
+
   if (!template) {
     return null
   }
@@ -56,16 +82,28 @@ function processTemplate(template, filename, config) {
     template.content = loadSrc(template.src, filename)
   }
 
+  let bindings
+  if (scriptSetup) {
+    const scriptSetupResult = compileScript(descriptor, {
+      id: filename,
+      refTransform: true,
+      ...vueJestConfig.compilerOptions
+    })
+    bindings = scriptSetupResult.bindings
+  }
+
   const userTemplateCompilerOptions = vueJestConfig.templateCompiler || {}
-  const result = compilerUtils.compileTemplate({
+  const result = compileTemplate({
     source: template.content,
     compiler: VueTemplateCompiler,
     filename: filename,
     isFunctional: template.attrs.functional,
     preprocessLang: template.lang,
     preprocessOptions: vueJestConfig[template.lang],
+    bindings,
     ...userTemplateCompilerOptions,
     compilerOptions: {
+      bindingMetadata: bindings,
       optimize: false,
       ...userTemplateCompilerOptions.compilerOptions
     }
@@ -92,14 +130,15 @@ function processStyle(styles, filename, config) {
 }
 
 module.exports = function(src, filename, config) {
-  const descriptor = compilerUtils.parse({
+  const descriptor = parse({
     source: src,
     compiler: VueTemplateCompiler,
     filename
   })
 
-  const templateResult = processTemplate(descriptor.template, filename, config)
+  const templateResult = processTemplate(descriptor, filename, config)
   const scriptResult = processScript(descriptor.script, filename, config)
+  const scriptSetupResult = processScriptSetup(descriptor, filename, config)
   const stylesResult = processStyle(descriptor.styles, filename, config)
   const customBlocksResult = processCustomBlocks(
     descriptor.customBlocks,
@@ -120,6 +159,7 @@ module.exports = function(src, filename, config) {
 
   const output = generateCode(
     scriptResult,
+    scriptSetupResult,
     templateResult,
     stylesResult,
     customBlocksResult,
@@ -127,6 +167,7 @@ module.exports = function(src, filename, config) {
   )
 
   const map = generateSourceMap(
+    // TODO Add scriptSetup
     scriptResult,
     src,
     filename,

--- a/packages/vue2-jest/package.json
+++ b/packages/vue2-jest/package.json
@@ -34,8 +34,8 @@
     "semantic-release": "^15.13.2",
     "ts-jest": "^28.0.1",
     "typescript": "^4.6.4",
-    "vue": "^2.4.2",
-    "vue-template-compiler": "^2.4.2"
+    "vue": "^2.7.2",
+    "vue-template-compiler": "^2.7.2"
   },
   "peerDependencies": {
     "@babel/core": "7.x",

--- a/packages/vue2-jest/package.json
+++ b/packages/vue2-jest/package.json
@@ -34,8 +34,8 @@
     "semantic-release": "^15.13.2",
     "ts-jest": "^28.0.1",
     "typescript": "^4.6.4",
-    "vue": "^2.7.2",
-    "vue-template-compiler": "^2.7.2"
+    "vue": "^2.7.7",
+    "vue-template-compiler": "^2.7.7"
   },
   "peerDependencies": {
     "@babel/core": "7.x",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1882,10 +1882,10 @@
     "@vue/compiler-core" "3.2.23"
     "@vue/shared" "3.2.23"
 
-"@vue/compiler-sfc@2.7.2":
-  version "2.7.2"
-  resolved "https://registry.yarnpkg.com/@vue/compiler-sfc/-/compiler-sfc-2.7.2.tgz#15ec0a39c81dad831add7da45d28de37e75fa577"
-  integrity sha512-khG5m63A4DSeHEOe5yyjHQY2TAE0pUXqKqxgauNUcFaa8M4+J55OWhagy8Bk8O6cO4GhKbQf2NDYzceijmOy8A==
+"@vue/compiler-sfc@2.7.7":
+  version "2.7.7"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-sfc/-/compiler-sfc-2.7.7.tgz#74aebb24c1ebfa22642c70f27ffaeca4dabdf692"
+  integrity sha512-Ah8dIuo6ZVPHTq9+s4rBU/YpJu3vGSNyeOTCrPrVPQnkUfnT5Ig+IKBhePuQWFXguYb2TuEWrEfiiX9DZ3aJlA==
   dependencies:
     "@babel/parser" "^7.18.4"
     postcss "^8.4.14"
@@ -10885,10 +10885,10 @@ vue-property-decorator@^10.0.0-rc.3:
   resolved "https://registry.yarnpkg.com/vue-property-decorator/-/vue-property-decorator-10.0.0-rc.3.tgz#bb0cb2c7c31dc41149eb432f2104fb82dc3d95be"
   integrity sha512-EGqjf8Lq+kTausZzfLB1ynWOcyay8ZLAc5p2VlKGEX2q+BjYw84oZxr6IcdwuxGIdNmriZqPUX6AlAluBdnbEg==
 
-vue-template-compiler@^2.7.2:
-  version "2.7.2"
-  resolved "https://registry.yarnpkg.com/vue-template-compiler/-/vue-template-compiler-2.7.2.tgz#656c2ccfd53696c52a9740645b7a9fda421d84e6"
-  integrity sha512-3PDLIPankm7b1YZHk6/mTz9kMZaDSd1Vhp1tFPITot5uW9WjnIyv6zRax3+j1kwF0DHmvfIVXMX8G+Rn/BHfaQ==
+vue-template-compiler@^2.7.7:
+  version "2.7.7"
+  resolved "https://registry.yarnpkg.com/vue-template-compiler/-/vue-template-compiler-2.7.7.tgz#9ac85dc50216d01fb5e2fb16b6c3f5ed11b4b104"
+  integrity sha512-vxOsjWhvDPyMW7QwXPecNmTNwKyXiF+j4KjBFjDxYPuY0xvqCT5o9WrapVItR/Nrh0XThfBaL19kXFSNYtbKmw==
   dependencies:
     de-indent "^1.0.2"
     he "^1.2.0"
@@ -10901,7 +10901,7 @@ vue-template-es2015-compiler@^1.9.0:
 "vue2-sass-importer-lib@file:e2e/2.x/sass-importer/lib":
   version "1.0.0"
   dependencies:
-    vue2-sass-importer-sass-lib "file:../../Library/Caches/Yarn/v6/npm-vue2-sass-importer-lib-1.0.0-8173eb07-74dd-4f87-b80c-57dc71227233-1657017062306/node_modules/sass-lib-v1"
+    vue2-sass-importer-sass-lib "file:../../Library/Caches/Yarn/v6/npm-vue2-sass-importer-lib-1.0.0-7ea9c798-4187-4843-8438-890703751297-1658071612744/node_modules/sass-lib-v1"
 
 "vue2-sass-importer-sass-lib@file:e2e/2.x/sass-importer/sass-lib-v1":
   version "1.0.0"
@@ -10912,7 +10912,7 @@ vue-template-es2015-compiler@^1.9.0:
 "vue3-sass-importer-lib@file:e2e/3.x/sass-importer/lib":
   version "1.0.0"
   dependencies:
-    vue3-sass-importer-sass-lib "file:../../Library/Caches/Yarn/v6/npm-vue3-sass-importer-lib-1.0.0-ffdc36b5-3387-41da-ae0b-a90940b3f3ab-1657017062307/node_modules/sass-lib-v1"
+    vue3-sass-importer-sass-lib "file:../../Library/Caches/Yarn/v6/npm-vue3-sass-importer-lib-1.0.0-6f2c27b2-1a8d-453e-a6a3-12b82bb6e5f4-1658071612745/node_modules/sass-lib-v1"
 
 "vue3-sass-importer-sass-lib@file:e2e/3.x/sass-importer/sass-lib-v1":
   version "1.0.0"
@@ -10920,12 +10920,12 @@ vue-template-es2015-compiler@^1.9.0:
 "vue3-sass-importer-sass-lib@file:e2e/3.x/sass-importer/sass-lib-v2":
   version "2.0.0"
 
-vue@^2.7.2:
-  version "2.7.2"
-  resolved "https://registry.yarnpkg.com/vue/-/vue-2.7.2.tgz#d42aba8d03c4e82d4b127f7b764a822cf19f9cdc"
-  integrity sha512-fQPKEfdiUP4bDlrGEjI5MOTkC5s/XIbnfKAx0B3MxJHI4qwh8FPLSo8/9tFkgFiRH3HwvcHjZQ1tCTifOUH0tg==
+vue@^2.7.7:
+  version "2.7.7"
+  resolved "https://registry.yarnpkg.com/vue/-/vue-2.7.7.tgz#e3a966944e461e4abb496c82362e8763e98e6527"
+  integrity sha512-osfkncsGCWqtch+YWYxbqTNQ9hl/UQ6TFRkdmK/VqAjuMpxzr5QotFsYpmJ1AB1ez2LJeIKXDmtMkXUotMOTsA==
   dependencies:
-    "@vue/compiler-sfc" "2.7.2"
+    "@vue/compiler-sfc" "2.7.7"
     csstype "^3.1.0"
 
 vue@^3.0.3:

--- a/yarn.lock
+++ b/yarn.lock
@@ -413,6 +413,11 @@
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.17.9.tgz#9c94189a6062f0291418ca021077983058e171ef"
   integrity sha512-vqUSBLP8dQHFPdPi9bc5GK9vRkYHJ49fsZdtoJ8EQ8ibpwk5rPKfvNIwChB0KVXcIjcepEBBd2VHC5r9Gy8ueg==
 
+"@babel/parser@^7.18.4":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.18.6.tgz#845338edecad65ebffef058d3be851f1d28a63bc"
+  integrity sha512-uQVSa9jJUe/G/304lXspfWVpKpK4euFLgGiMQFOCpM/bgcAdeoHwi/OQz23O9GK2osz26ZiXRRV9aV+Yl1O8tw==
+
 "@babel/parser@^7.6.0", "@babel/parser@^7.9.6":
   version "7.15.5"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.15.5.tgz#d33a58ca69facc05b26adfe4abebfed56c1c2dac"
@@ -1876,6 +1881,15 @@
   dependencies:
     "@vue/compiler-core" "3.2.23"
     "@vue/shared" "3.2.23"
+
+"@vue/compiler-sfc@2.7.2":
+  version "2.7.2"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-sfc/-/compiler-sfc-2.7.2.tgz#15ec0a39c81dad831add7da45d28de37e75fa577"
+  integrity sha512-khG5m63A4DSeHEOe5yyjHQY2TAE0pUXqKqxgauNUcFaa8M4+J55OWhagy8Bk8O6cO4GhKbQf2NDYzceijmOy8A==
+  dependencies:
+    "@babel/parser" "^7.18.4"
+    postcss "^8.4.14"
+    source-map "^0.6.1"
 
 "@vue/compiler-sfc@3.2.22":
   version "3.2.22"
@@ -3767,6 +3781,11 @@ csstype@^2.6.8:
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.17.tgz#4cf30eb87e1d1a005d8b6510f95292413f6a1c0e"
   integrity sha512-u1wmTI1jJGzCJzWndZo8mk4wnPTZd1eOIYTYvuEyOQGfmDl3TrabCCfKnOC86FZwW/9djqTl933UF/cS425i9A==
 
+csstype@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.0.tgz#4ddcac3718d787cf9df0d1b7d15033925c8f29f2"
+  integrity sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA==
+
 currently-unhandled@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/currently-unhandled/-/currently-unhandled-0.4.1.tgz#988df33feab191ef799a61369dd76c17adf957ea"
@@ -5242,7 +5261,7 @@ hash-sum@^1.0.2:
   resolved "https://registry.yarnpkg.com/hash-sum/-/hash-sum-1.0.2.tgz#33b40777754c6432573c120cc3808bbd10d47f04"
   integrity sha1-M7QHd3VMZDJXPBIMw4CLvRDUfwQ=
 
-he@^1.1.0:
+he@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
@@ -7538,6 +7557,11 @@ nanoid@^3.1.23:
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.25.tgz#09ca32747c0e543f0e1814b7d3793477f9c8e152"
   integrity sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==
 
+nanoid@^3.3.4:
+  version "3.3.4"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.4.tgz#730b67e3cd09e2deacf03c027c81c9d9dbc5e8ab"
+  integrity sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==
+
 nanomatch@^1.2.9:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"
@@ -8531,6 +8555,15 @@ postcss@^8.1.10:
     colorette "^1.2.2"
     nanoid "^3.1.23"
     source-map-js "^0.6.2"
+
+postcss@^8.4.14:
+  version "8.4.14"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.14.tgz#ee9274d5622b4858c1007a74d76e42e56fd21caf"
+  integrity sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==
+  dependencies:
+    nanoid "^3.3.4"
+    picocolors "^1.0.0"
+    source-map-js "^1.0.2"
 
 prelude-ls@~1.1.2:
   version "1.1.2"
@@ -10852,13 +10885,13 @@ vue-property-decorator@^10.0.0-rc.3:
   resolved "https://registry.yarnpkg.com/vue-property-decorator/-/vue-property-decorator-10.0.0-rc.3.tgz#bb0cb2c7c31dc41149eb432f2104fb82dc3d95be"
   integrity sha512-EGqjf8Lq+kTausZzfLB1ynWOcyay8ZLAc5p2VlKGEX2q+BjYw84oZxr6IcdwuxGIdNmriZqPUX6AlAluBdnbEg==
 
-vue-template-compiler@^2.4.2, vue-template-compiler@^2.5.21:
-  version "2.6.14"
-  resolved "https://registry.yarnpkg.com/vue-template-compiler/-/vue-template-compiler-2.6.14.tgz#a2f0e7d985670d42c9c9ee0d044fed7690f4f763"
-  integrity sha512-ODQS1SyMbjKoO1JBJZojSw6FE4qnh9rIpUZn2EUT86FKizx9uH5z6uXiIrm4/Nb/gwxTi/o17ZDEGWAXHvtC7g==
+vue-template-compiler@^2.7.2:
+  version "2.7.2"
+  resolved "https://registry.yarnpkg.com/vue-template-compiler/-/vue-template-compiler-2.7.2.tgz#656c2ccfd53696c52a9740645b7a9fda421d84e6"
+  integrity sha512-3PDLIPankm7b1YZHk6/mTz9kMZaDSd1Vhp1tFPITot5uW9WjnIyv6zRax3+j1kwF0DHmvfIVXMX8G+Rn/BHfaQ==
   dependencies:
     de-indent "^1.0.2"
-    he "^1.1.0"
+    he "^1.2.0"
 
 vue-template-es2015-compiler@^1.9.0:
   version "1.9.1"
@@ -10868,7 +10901,7 @@ vue-template-es2015-compiler@^1.9.0:
 "vue2-sass-importer-lib@file:e2e/2.x/sass-importer/lib":
   version "1.0.0"
   dependencies:
-    vue2-sass-importer-sass-lib "file:../../.cache/yarn/v6/npm-vue2-sass-importer-lib-1.0.0-1087f856-8699-4ac6-a0fa-2288988256c2-1656107462461/node_modules/sass-lib-v1"
+    vue2-sass-importer-sass-lib "file:../../Library/Caches/Yarn/v6/npm-vue2-sass-importer-lib-1.0.0-8173eb07-74dd-4f87-b80c-57dc71227233-1657017062306/node_modules/sass-lib-v1"
 
 "vue2-sass-importer-sass-lib@file:e2e/2.x/sass-importer/sass-lib-v1":
   version "1.0.0"
@@ -10879,7 +10912,7 @@ vue-template-es2015-compiler@^1.9.0:
 "vue3-sass-importer-lib@file:e2e/3.x/sass-importer/lib":
   version "1.0.0"
   dependencies:
-    vue3-sass-importer-sass-lib "file:../../.cache/yarn/v6/npm-vue3-sass-importer-lib-1.0.0-c866bb73-f527-47b9-932d-498dea4cf3d0-1656107462461/node_modules/sass-lib-v1"
+    vue3-sass-importer-sass-lib "file:../../Library/Caches/Yarn/v6/npm-vue3-sass-importer-lib-1.0.0-ffdc36b5-3387-41da-ae0b-a90940b3f3ab-1657017062307/node_modules/sass-lib-v1"
 
 "vue3-sass-importer-sass-lib@file:e2e/3.x/sass-importer/sass-lib-v1":
   version "1.0.0"
@@ -10887,10 +10920,13 @@ vue-template-es2015-compiler@^1.9.0:
 "vue3-sass-importer-sass-lib@file:e2e/3.x/sass-importer/sass-lib-v2":
   version "2.0.0"
 
-vue@^2.4.2, vue@^2.5.21:
-  version "2.6.14"
-  resolved "https://registry.yarnpkg.com/vue/-/vue-2.6.14.tgz#e51aa5250250d569a3fbad3a8a5a687d6036e235"
-  integrity sha512-x2284lgYvjOMj3Za7kqzRcUSxBboHqtgRE2zlos1qWaOye5yUmHn42LB1250NJBLRwEcdrB0JRwyPTEPhfQjiQ==
+vue@^2.7.2:
+  version "2.7.2"
+  resolved "https://registry.yarnpkg.com/vue/-/vue-2.7.2.tgz#d42aba8d03c4e82d4b127f7b764a822cf19f9cdc"
+  integrity sha512-fQPKEfdiUP4bDlrGEjI5MOTkC5s/XIbnfKAx0B3MxJHI4qwh8FPLSo8/9tFkgFiRH3HwvcHjZQ1tCTifOUH0tg==
+  dependencies:
+    "@vue/compiler-sfc" "2.7.2"
+    csstype "^3.1.0"
 
 vue@^3.0.3:
   version "3.2.23"


### PR DESCRIPTION
This PR:

- updates all Vue 2 dependencies (`vue` and `vue-template-compiler`) to the latest version (`2.7.7`)
- adds support for parsing components using the `<script setup>` syntax in Vue 2.7 components
  - most of the code (and e2e test) was just copied from the `vue3-jest` package (https://github.com/vuejs/vue-jest/blob/master/packages/vue3-jest/lib/process.js#L51)