### PR TITLE
fix(vue3-jest): reduce `getTypeScriptConfig` calls

### DIFF
--- a/e2e/3.x/basic/__snapshots__/test.js.snap
+++ b/e2e/3.x/basic/__snapshots__/test.js.snap
@@ -32,19 +32,25 @@ var _default = {
 };
 exports[\\"default\\"] = _default;
 \\"use strict\\";
-Object.defineProperty(exports, \\"__esModule\\", { value: true });
-exports.render = void 0;
-var vue_1 = require(\\"vue\\");
-var _hoisted_1 = { class: \\"hello\\" };
-function render(_ctx, _cache) {
-    return ((0, vue_1.openBlock)(), (0, vue_1.createElementBlock)(\\"div\\", _hoisted_1, [
-        (0, vue_1.createElementVNode)(\\"h1\\", {
-            class: (0, vue_1.normalizeClass)(_ctx.headingClasses)
-        }, (0, vue_1.toDisplayString)(_ctx.msg), 3 /* TEXT, CLASS */)
-    ]));
-}
+
+Object.defineProperty(exports, \\"__esModule\\", {
+  value: true
+});
 exports.render = render;
-;exports.default = {...exports.default, render};;exports.default = {...exports.default, __cssModules: {\\"css\\":{\\"testA\\":\\"testA\\"},\\"$style\\":{\\"testB\\":\\"testB\\"}}}"
+
+var _vue = require(\\"vue\\");
+
+var _hoisted_1 = {
+  \\"class\\": \\"hello\\"
+};
+
+function render(_ctx, _cache) {
+  return (0, _vue.openBlock)(), (0, _vue.createElementBlock)(\\"div\\", _hoisted_1, [(0, _vue.createElementVNode)(\\"h1\\", {
+    \\"class\\": (0, _vue.normalizeClass)(_ctx.headingClasses)
+  }, (0, _vue.toDisplayString)(_ctx.msg), 3
+  /* TEXT, CLASS */
+  )]);
+};exports.default = {...exports.default, render};;exports.default = {...exports.default, __cssModules: {\\"css\\":{\\"testA\\":\\"testA\\"},\\"$style\\":{\\"testB\\":\\"testB\\"}}}"
 `;
 
 exports[`generates source maps using src attributes 1`] = `
@@ -79,17 +85,23 @@ var _default = {
 };
 exports[\\"default\\"] = _default;
 \\"use strict\\";
-Object.defineProperty(exports, \\"__esModule\\", { value: true });
-exports.render = void 0;
-var vue_1 = require(\\"vue\\");
-var _hoisted_1 = { class: \\"hello\\" };
-function render(_ctx, _cache) {
-    return ((0, vue_1.openBlock)(), (0, vue_1.createElementBlock)(\\"div\\", _hoisted_1, [
-        (0, vue_1.createElementVNode)(\\"h1\\", {
-            class: (0, vue_1.normalizeClass)(_ctx.headingClasses)
-        }, (0, vue_1.toDisplayString)(_ctx.msg), 3 /* TEXT, CLASS */)
-    ]));
-}
+
+Object.defineProperty(exports, \\"__esModule\\", {
+  value: true
+});
 exports.render = render;
-;exports.default = {...exports.default, render};"
+
+var _vue = require(\\"vue\\");
+
+var _hoisted_1 = {
+  \\"class\\": \\"hello\\"
+};
+
+function render(_ctx, _cache) {
+  return (0, _vue.openBlock)(), (0, _vue.createElementBlock)(\\"div\\", _hoisted_1, [(0, _vue.createElementVNode)(\\"h1\\", {
+    \\"class\\": (0, _vue.normalizeClass)(_ctx.headingClasses)
+  }, (0, _vue.toDisplayString)(_ctx.msg), 3
+  /* TEXT, CLASS */
+  )]);
+};exports.default = {...exports.default, render};"
 `;

--- a/packages/vue3-jest/lib/process.js
+++ b/packages/vue3-jest/lib/process.js
@@ -71,6 +71,12 @@ function processScriptSetup(descriptor, filePath, config) {
   return result
 }
 
+/**
+ * Process SFC <template> section.
+ * @param {import('@vue/compiler-sfc').SFCDescriptor} descriptor
+ * @param {string} filename
+ * @param {import('@jest/transform').TransformOptions} config
+ */
 function processTemplate(descriptor, filename, config) {
   const { template, scriptSetup } = descriptor
 
@@ -118,24 +124,23 @@ function processTemplate(descriptor, filename, config) {
 
   logResultErrors(result)
 
-  const tsconfig = getTypeScriptConfig(vueJestConfig.tsConfig)
-
-  if (tsconfig) {
-    // they are using TypeScript.
-    const { transpileModule } = require('typescript')
-    const { outputText } = transpileModule(result.code, { tsconfig })
-    return { code: outputText }
-  } else {
-    // babel
-    const babelify = transform(result.code, {
-      filename: 'file.js',
-      presets: ['@babel/preset-env']
-    })
-
-    return {
-      code: babelify.code
+  // TypeScript
+  if (isTS) {
+    const tsconfig = getTypeScriptConfig(vueJestConfig.tsConfig)
+    if (tsconfig) {
+      const { transpileModule } = require('typescript')
+      const { outputText } = transpileModule(result.code, { tsconfig })
+      return { code: outputText }
     }
   }
+
+  // babel
+  const babelify = transform(result.code, {
+    filename: 'file.js',
+    presets: ['@babel/preset-env']
+  })
+
+  return { code: babelify.code }
 }
 
 function processStyle(styles, filename, config) {


### PR DESCRIPTION
**:warning:This PR contains BREAKING CHANGES!!:warning:**

In `@vue/vue3-jest`, `getTypeScriptConfig` calls every times whether project uses TypeScript or not.
With that, js users will get unnecessary "Not found tsconfig.json" warnings.
Fix #490 

## Changes
- Restrict calling `getTypeScriptConfig` function to when using `<script lang="ts">`, `<script lang="tsx">`, or `<script lang="typescript">`.

### Breaking Change
- Even if there is a `tsconfig.json` file in project, TypeScript will not transpile if `lang=ts` is not specified

|script|`tsconfig.json`|transpile|
|------|---------------|----------|
|JavaScript|No|`@babel/preset-env`|
|TypeScript|No|`@babel/preset-env` (with "Not found tsconfig.json" warning)|
|JavaScript|Yes|`typescript` -> `@babel/preset-env`|
|TypeScript|Yes|`typescript`|
