### PR TITLE
Don't set inputSourceMap on babel-jest transform

### DIFF
--- a/packages/vue2-jest/lib/transformers/typescript.js
+++ b/packages/vue2-jest/lib/transformers/typescript.js
@@ -21,13 +21,11 @@ module.exports = scriptLang => ({
 
     res.outputText = stripInlineSourceMap(res.outputText)
 
-    const inputSourceMap = res.sourceMapText && JSON.parse(res.sourceMapText)
-
     const customTransformer =
       getCustomTransformer(vueJestConfig['transform'], 'js') || {}
     const transformer = customTransformer.process
       ? customTransformer
-      : babelJest.createTransformer({ inputSourceMap })
+      : babelJest.createTransformer()
 
     return transformer.process(res.outputText, filePath, config)
   }


### PR DESCRIPTION
When babel-jest merges the inputSourceMap and the outputSourceMap
it appears to remove names from the resulting sourceMap that are
still referenced by elements of the source map.  Not passing the
inputSourceMap appears to solve #474 and still provide source
coverage, but someone who knows how this is supposed to work
should look more closely.