### PR TITLE
Fix "ReferenceError: true__options__ is not defined"

### DIFF
--- a/packages/vue2-jest/lib/generate-code.js
+++ b/packages/vue2-jest/lib/generate-code.js
@@ -54,7 +54,7 @@ module.exports = function generateCode(
     )
 
     node.add(
-      `__options__.render = render\n` +
+      `\n__options__.render = render\n` +
         `${namespace}.staticRenderFns = staticRenderFns\n`
     )
 


### PR DESCRIPTION
No idea if this is the cleanest approach, but at least it fixes the following error for me:

```
 FAIL  packages/....spec.ts
  ● Test suite failed to run

    ReferenceError: true__options__ is not defined
```

This is caused by a missing newline before the `__options__` in the generated code.

before:
```
var staticRenderFns = []
render._withStripped = true__options__.render = render
__options__.staticRenderFns = staticRenderFns
```

with this PR:
``` 
var staticRenderFns = []
render._withStripped = true
__options__.render = render
__options__.staticRenderFns = staticRenderFns
```

For the record: this is with Vue 2.7