### PR TITLE
fix: Map lines for script block

### DIFF
--- a/e2e/2.x/basic/__snapshots__/test.js.snap
+++ b/e2e/2.x/basic/__snapshots__/test.js.snap
@@ -3,25 +3,35 @@
 exports[`generates source maps for .vue files 1`] = `
 {
   "file": "./components/Basic.vue",
-  "mappings": ";;;;;;eACe;AACbA,MAAI,EAAE,OADO;AAEbC,UAAQ,EAAE;AACRC,kBAAc,EAAE,SAASA,cAAT,GAA0B;AACxC,aAAO;AACLC,WAAG,EAAE,KAAKC,OADL;AAELC,YAAI,EAAE,CAAC,KAAKD,OAFP;AAGLE,cAAM,EAAE,KAAKF;AAHR,OAAP;AAKD;AAPO,GAFG;AAWbG,MAAI,EAAE,SAASA,IAAT,GAAgB;AACpB,WAAO;AACLC,SAAG,EAAE,4BADA;AAELJ,aAAO,EAAE;AAFJ,KAAP;AAID,GAhBY;AAiBbK,SAAO,EAAE;AACPC,eAAW,EAAE,SAASA,WAAT,GAAuB;AAClC,WAAKN,OAAL,GAAe,CAAC,KAAKA,OAArB;AACD;AAHM;AAjBI,C",
-  "names": [
-    "name",
-    "computed",
-    "headingClasses",
-    "red",
-    "isCrazy",
-    "blue",
-    "shadow",
-    "data",
-    "msg",
-    "methods",
-    "toggleClass",
-  ],
+  "mappings": ";;;;;;eAuBe;AACb,MAAI,EAAE,OADO;AAEb,UAAQ,EAAE;AACR,kBAAc,EAAE,SAAS,cAAT,GAA0B;AACxC,aAAO;AACL,WAAG,EAAE,KAAK,OADL;AAEL,YAAI,EAAE,CAAC,KAAK,OAFP;AAGL,cAAM,EAAE,KAAK;AAHR,OAAP;AAKD;AAPO,GAFG;AAWb,MAAI,EAAE,SAAS,IAAT,GAAgB;AACpB,WAAO;AACL,SAAG,EAAE,4BADA;AAEL,aAAO,EAAE;AAFJ,KAAP;AAID,GAhBY;AAiBb,SAAO,EAAE;AACP,eAAW,EAAE,SAAS,WAAT,GAAuB;AAClC,WAAK,OAAL,GAAe,CAAC,KAAK,OAArB;AACD;AAHM;AAjBI",
+  "names": [],
   "sources": [
-    "Basic.vue",
+    "components/Basic.vue",
   ],
   "sourcesContent": [
-    "
+    "<template>
+  <div class="hello">
+    <h1 :class="headingClasses">{{ msg }}</h1>
+  </div>
+</template>
+
+<style module="css">
+.testA {
+  background-color: red;
+}
+</style>
+<style module>
+.testB {
+  background-color: blue;
+}
+</style>
+<style>
+.testC {
+  background-color: blue;
+}
+</style>
+
+<script>
 export default {
   name: 'basic',
   computed: {
@@ -45,6 +55,7 @@ export default {
     }
   }
 }
+</script>
 ",
   ],
   "version": 3,

--- a/packages/vue2-jest/lib/process.js
+++ b/packages/vue2-jest/lib/process.js
@@ -48,6 +48,7 @@ function processScript(scriptPart, filePath, config) {
 
   const result = transformer.process(scriptPart.content, filePath, config)
   result.code = stripInlineSourceMap(result.code)
+  result.map = mapLines(scriptPart.map, result.map)
   result.externalSrc = externalSrc
   return result
 }


### PR DESCRIPTION
I'm using vue2-jest and code coverage is broken for a while now. I noticed a difference between `processScript` in vue2-jest vs. vue3-jest:

vue2-jest:

https://github.com/vuejs/vue-jest/blob/dbe8022c59407b7474e78d2514c317685680c15e/packages/vue2-jest/lib/process.js#L35-L53

vue3-jest:

https://github.com/vuejs/vue-jest/blob/dbe8022c59407b7474e78d2514c317685680c15e/packages/vue3-jest/lib/process.js#L30-L49

The call to `mapLines` is missing for vue2-jest.

Adding the call, I can see two differences in the tests:
- The changed snapshot in the diff. Previously the `<template>` and `<style>` block didn't show up at all in the html coverage output. Now they do.
-  Looking for example at the `e2e/2.x/basic/coverage/lcov-report/basic/components/TemplateString.vue.html` file, I see the covered lines now to be in the script block as expected. Before this change they were put somewhere on the template block, which didn't make sense.

The change also made code coverage in my repo work properly again, at least I think so from the output I get.