### PR TITLE
docs: Jest globals key is always `vue-jest`

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ A `package.json` Example
       "^.+\\.vue$": "@vue/vue2-jest"
     },
     "globals": {
-      "@vue/vue2-jest": {
+      "vue-jest": {
         "transform": {
           "your-custom-block": "./custom-block-processor.js"
         }
@@ -135,7 +135,7 @@ A `jest.config.js` Example - If you're using a dedicated configuration file like
 ```js
 module.exports = {
   globals: {
-    '@vue/vue2-jest': {
+    'vue-jest': {
       transform: {
         'your-custom-block': require('./custom-block-processor')
       }
@@ -170,7 +170,7 @@ You can provide [TemplateCompileOptions](https://github.com/vuejs/component-comp
 {
   "jest": {
     "globals": {
-      "@vue/vue2-jest": {
+      "vue-jest": {
         "templateCompiler": {
           "transpileOptions": {
             "transforms": {
@@ -195,7 +195,7 @@ You can provide [TemplateCompileOptions](https://github.com/vuejs/component-comp
   {
     "jest": {
       "globals": {
-        "@vue/vue2-jest": {
+        "vue-jest": {
           "pug": {
             "basedir": "mybasedir"
           }


### PR DESCRIPTION
The key used to get config is `vue-jest` in both [`@vue/vue2-jest`](https://github.com/vuejs/vue-jest/blob/3dc76ff8491d149d89a8ba5deb02f517f1535f98/packages/vue2-jest/lib/utils.js#L57) and [`@vue/vue3-jest`](https://github.com/vuejs/vue-jest/blob/3dc76ff8491d149d89a8ba5deb02f517f1535f98/packages/vue3-jest/lib/utils.js#L57), not the respective Vue/Jest version dependent package variant name.

https://github.com/vuejs/vue-jest/blob/3dc76ff8491d149d89a8ba5deb02f517f1535f98/packages/vue2-jest/lib/utils.js#L57

https://github.com/vuejs/vue-jest/blob/3dc76ff8491d149d89a8ba5deb02f517f1535f98/packages/vue3-jest/lib/utils.js#L57