### PR TITLE
fix: allow importing relative paths in global resources

### DIFF
--- a/e2e/2.x/style/colors.less
+++ b/e2e/2.x/style/colors.less
@@ -1,0 +1,1 @@
+@primary-color: "red";

--- a/e2e/2.x/style/colors.scss
+++ b/e2e/2.x/style/colors.scss
@@ -1,0 +1,1 @@
+$primary-color: #333;

--- a/e2e/2.x/style/variables.less
+++ b/e2e/2.x/style/variables.less
@@ -1,1 +1,3 @@
-@primary-color: "red";
+@import "./colors.less";
+
+@font-size: 16px;

--- a/e2e/2.x/style/variables.scss
+++ b/e2e/2.x/style/variables.scss
@@ -1,1 +1,3 @@
-$primary-color: #333;
+@import './colors.scss';
+
+$font-size: 16px;

--- a/e2e/3.x/style/colors.less
+++ b/e2e/3.x/style/colors.less
@@ -1,0 +1,1 @@
+@primary-color: "red";

--- a/e2e/3.x/style/colors.scss
+++ b/e2e/3.x/style/colors.scss
@@ -1,0 +1,1 @@
+$primary-color: #333;

--- a/e2e/3.x/style/variables.less
+++ b/e2e/3.x/style/variables.less
@@ -1,1 +1,3 @@
-@primary-color: "red";
+@import "./colors.less";
+
+@font-size: 16px;

--- a/e2e/3.x/style/variables.scss
+++ b/e2e/3.x/style/variables.scss
@@ -1,1 +1,3 @@
-$primary-color: #333;
+@import './colors.scss';
+
+$font-size: 16px;

--- a/packages/vue2-jest/lib/process-style.js
+++ b/packages/vue2-jest/lib/process-style.js
@@ -1,5 +1,4 @@
 const path = require('path')
-const fs = require('fs')
 const cssTree = require('css-tree')
 const getVueJestConfig = require('./utils').getVueJestConfig
 const compileStyle = require('@vue/component-compiler-utils').compileStyle
@@ -12,12 +11,21 @@ function getGlobalResources(resources, lang) {
   let globalResources = ''
   if (resources && resources[lang]) {
     globalResources = resources[lang]
-      .map(resource => path.resolve(process.cwd(), resource))
-      .filter(resourcePath => fs.existsSync(resourcePath))
-      .map(resourcePath => fs.readFileSync(resourcePath).toString())
-      .join('\n')
+      .map(resource => {
+        const absolutePath = path.resolve(process.cwd(), resource)
+        return `${getImportLine(lang, absolutePath)}\n`
+      })
+      .join('')
   }
   return globalResources
+}
+
+function getImportLine(lang, filePath) {
+  const importLines = {
+    default: `@import "${filePath}";`,
+    sass: `@import "${filePath}"`
+  }
+  return importLines[lang] || importLines.default
 }
 
 function extractClassMap(cssCode) {
@@ -35,6 +43,7 @@ function extractClassMap(cssCode) {
 function getPreprocessOptions(lang, filePath, jestConfig) {
   if (lang === 'scss' || lang === 'sass') {
     return {
+      filename: filePath,
       importer: (url, prev, done) => ({
         file: applyModuleNameMapper(
           url,


### PR DESCRIPTION
It seems like the fix I've made for relative paths in global resources in vue2-jest v26 (https://github.com/vuejs/vue-jest/pull/373) has not been ported to the other versions (not in v27, v28, v29). We recently upgraded to v29 and faced the same issue so this PR is making the same changes, but for v29 in both Vue 2 and Vue 3 (I tested it and it works as expected).

More details found in my previous PR: https://github.com/vuejs/vue-jest/pull/373